### PR TITLE
Fix missing requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r portfolio-api/requirements.txt


### PR DESCRIPTION
## Summary
- add root requirements file referencing portfolio API dependencies

## Testing
- `python3 -m pip install -r requirements.txt`
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_684b04e4ffc8833092175b8dd03d5a5e