### PR TITLE
Add currency support to portfolio tracker UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,11 @@ The front-end uses Vite environment variables. Copy `.env.example` in `portfolio
 
 ```
 VITE_API_URL=http://localhost:5000/api/portfolio
+VITE_BASE_CURRENCY=USD
 ```
 
 `VITE_API_URL` should point to the portfolio API base URL.
+`VITE_BASE_CURRENCY` sets the default currency shown in the UI.
 
 ## Example setup
 
@@ -144,7 +146,7 @@ The HTML page used for quick testing of these endpoints has been moved to
 ## Usage
 
 1. Start the backend and frontend using the steps above.
-2. Use the web interface to add transactions and view holdings.
+2. Use the web interface to add transactions (choose a currency for each entry) and view holdings.
 3. Call the API directly (e.g., using `curl` or Postman) to integrate with other tools.
 4. Update prices periodically using the "Update Prices" button or the corresponding API endpoint.
 

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -92,9 +92,10 @@ pnpm run dev  # Frontend runs on http://localhost:5173
 2. Enter stock symbol (e.g., AAPL, GOOGL, MSFT)
 3. Click search to fetch current info
 4. Select transaction type (Buy/Sell)
-5. Enter quantity and price
-6. Set date
-7. Click "Add Transaction"
+5. Choose currency (USD, EUR, SEK, GBP, JPY)
+6. Enter quantity and price
+7. Set date
+8. Click "Add Transaction"
 
 ### Viewing Portfolio Performance
 

--- a/portfolio-tracker/.env.example
+++ b/portfolio-tracker/.env.example
@@ -1,1 +1,2 @@
 VITE_API_URL=http://localhost:5000/api/portfolio
+VITE_BASE_CURRENCY=USD

--- a/portfolio-tracker/src/components/AddTransactionModal.jsx
+++ b/portfolio-tracker/src/components/AddTransactionModal.jsx
@@ -6,8 +6,10 @@ import { Label } from '@/components/ui/label.jsx'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select.jsx'
 import { Alert, AlertDescription } from '@/components/ui/alert.jsx'
 import { Loader2, Search } from 'lucide-react'
+import { getCurrencySymbol } from '@/lib/utils.js'
 
 const API_BASE_URL = import.meta.env.VITE_API_URL
+const BASE_CURRENCY = import.meta.env.VITE_BASE_CURRENCY || 'USD'
 
 function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
   const [formData, setFormData] = useState({
@@ -15,7 +17,8 @@ function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
     transaction_type: 'buy',
     quantity: '',
     price_per_share: '',
-    transaction_date: new Date().toISOString().split('T')[0]
+    transaction_date: new Date().toISOString().split('T')[0],
+    currency: BASE_CURRENCY
   })
   const [loading, setLoading] = useState(false)
   const [searchingStock, setSearchingStock] = useState(false)
@@ -135,7 +138,8 @@ function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
           ...formData,
           symbol: formData.symbol.trim().toUpperCase(),
           quantity: parseInt(formData.quantity),
-          price_per_share: parseFloat(formData.price_per_share)
+          price_per_share: parseFloat(formData.price_per_share),
+          currency: formData.currency
         })
       })
       
@@ -160,7 +164,8 @@ function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
       transaction_type: 'buy',
       quantity: '',
       price_per_share: '',
-      transaction_date: new Date().toISOString().split('T')[0]
+      transaction_date: new Date().toISOString().split('T')[0],
+      currency: BASE_CURRENCY
     })
     setError('')
     setStockInfo(null)
@@ -229,13 +234,35 @@ function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
               <div className="text-sm text-gray-600 bg-gray-50 p-2 rounded">
                 <p><strong>{stockInfo.symbol}</strong> - {stockInfo.company_name}</p>
                 {stockInfo.current_price && (
-                  <p>Current Price: ${stockInfo.current_price.toFixed(2)}</p>
+                  <p>
+                    Current Price: {getCurrencySymbol(BASE_CURRENCY)}{stockInfo.current_price.toFixed(2)}
+                  </p>
                 )}
               </div>
             )}
           </div>
 
-          {/* Transaction Type */}
+        {/* Currency */}
+        <div className="space-y-2">
+          <Label htmlFor="currency">Currency</Label>
+          <Select
+            value={formData.currency}
+            onValueChange={(value) => handleInputChange('currency', value)}
+          >
+            <SelectTrigger>
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="USD">USD</SelectItem>
+              <SelectItem value="EUR">EUR</SelectItem>
+              <SelectItem value="SEK">SEK</SelectItem>
+              <SelectItem value="GBP">GBP</SelectItem>
+              <SelectItem value="JPY">JPY</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Transaction Type */}
           <div className="space-y-2">
             <Label htmlFor="transaction_type">Transaction Type</Label>
             <Select
@@ -267,7 +294,9 @@ function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
 
           {/* Price per Share */}
           <div className="space-y-2">
-            <Label htmlFor="price_per_share">Price per Share ($)</Label>
+            <Label htmlFor="price_per_share">
+              Price per Share ({getCurrencySymbol(formData.currency)})
+            </Label>
             <Input
               id="price_per_share"
               type="number"
@@ -296,7 +325,8 @@ function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
             <div className="bg-gray-50 p-3 rounded">
               <p className="text-sm text-gray-600">Total Transaction Value:</p>
               <p className="text-lg font-semibold">
-                ${(parseInt(formData.quantity || 0) * parseFloat(formData.price_per_share || 0)).toLocaleString()}
+                {getCurrencySymbol(formData.currency)}
+                {(parseInt(formData.quantity || 0) * parseFloat(formData.price_per_share || 0)).toLocaleString()}
               </p>
             </div>
           )}

--- a/portfolio-tracker/src/components/StockHoldings.jsx
+++ b/portfolio-tracker/src/components/StockHoldings.jsx
@@ -4,8 +4,10 @@ import { Button } from '@/components/ui/button.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.jsx'
 import { TrendingUp, TrendingDown, RefreshCw, ExternalLink } from 'lucide-react'
+import { getCurrencySymbol } from '@/lib/utils.js'
 
 const API_BASE_URL = import.meta.env.VITE_API_URL
+const BASE_CURRENCY = import.meta.env.VITE_BASE_CURRENCY || 'USD'
 
 function StockHoldings({ portfolioData, onRefresh, loading }) {
   const [updatingStock, setUpdatingStock] = useState(null)
@@ -86,11 +88,13 @@ function StockHoldings({ portfolioData, onRefresh, loading }) {
                     {stock.quantity.toLocaleString()}
                   </TableCell>
                   <TableCell className="text-right">
-                    ${stock.avg_cost_basis?.toFixed(2) || 'N/A'}
+                    {getCurrencySymbol(BASE_CURRENCY)}
+                    {stock.avg_cost_basis?.toFixed(2) || 'N/A'}
                   </TableCell>
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
-                      ${stock.current_price?.toFixed(2) || 'N/A'}
+                      {getCurrencySymbol(BASE_CURRENCY)}
+                      {stock.current_price?.toFixed(2) || 'N/A'}
                       {stock.last_updated && (
                         <span className="text-xs text-gray-500">
                           {new Date(stock.last_updated).toLocaleDateString()}
@@ -99,7 +103,8 @@ function StockHoldings({ portfolioData, onRefresh, loading }) {
                     </div>
                   </TableCell>
                   <TableCell className="text-right font-medium">
-                    ${stock.current_value?.toLocaleString() || 'N/A'}
+                    {getCurrencySymbol(BASE_CURRENCY)}
+                    {stock.current_value?.toLocaleString() || 'N/A'}
                   </TableCell>
                   <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
@@ -108,8 +113,9 @@ function StockHoldings({ portfolioData, onRefresh, loading }) {
                       ) : (
                         <TrendingDown className="h-4 w-4 text-red-600" />
                       )}
-                      <span className={`font-medium ${stock.total_gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                        ${stock.total_gain?.toLocaleString() || 'N/A'}
+                      <span className={`font-medium ${stock.total_gain >= 0 ? 'text-green-600' : 'text-red-600'}`}> 
+                        {getCurrencySymbol(BASE_CURRENCY)}
+                        {stock.total_gain?.toLocaleString() || 'N/A'}
                       </span>
                     </div>
                   </TableCell>
@@ -161,13 +167,15 @@ function StockHoldings({ portfolioData, onRefresh, loading }) {
             <div>
               <p className="text-gray-600">Total Value</p>
               <p className="font-medium">
-                ${portfolioData.reduce((sum, stock) => sum + (stock.current_value || 0), 0).toLocaleString()}
+                {getCurrencySymbol(BASE_CURRENCY)}
+                {portfolioData.reduce((sum, stock) => sum + (stock.current_value || 0), 0).toLocaleString()}
               </p>
             </div>
             <div>
               <p className="text-gray-600">Total Gain/Loss</p>
               <p className={`font-medium ${portfolioData.reduce((sum, stock) => sum + (stock.total_gain || 0), 0) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                ${portfolioData.reduce((sum, stock) => sum + (stock.total_gain || 0), 0).toLocaleString()}
+                {getCurrencySymbol(BASE_CURRENCY)}
+                {portfolioData.reduce((sum, stock) => sum + (stock.total_gain || 0), 0).toLocaleString()}
               </p>
             </div>
           </div>

--- a/portfolio-tracker/src/components/TransactionHistory.jsx
+++ b/portfolio-tracker/src/components/TransactionHistory.jsx
@@ -5,8 +5,10 @@ import { Badge } from '@/components/ui/badge.jsx'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.jsx'
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle, AlertDialogTrigger } from '@/components/ui/alert-dialog.jsx'
 import { Trash2, TrendingUp, TrendingDown } from 'lucide-react'
+import { getCurrencySymbol } from '@/lib/utils.js'
 
 const API_BASE_URL = import.meta.env.VITE_API_URL
+const BASE_CURRENCY = import.meta.env.VITE_BASE_CURRENCY || 'USD'
 
 function TransactionHistory({ transactions, onTransactionDeleted }) {
   const [deletingTransaction, setDeletingTransaction] = useState(null)
@@ -91,10 +93,12 @@ function TransactionHistory({ transactions, onTransactionDeleted }) {
                     {transaction.quantity.toLocaleString()}
                   </TableCell>
                   <TableCell className="text-right">
-                    ${transaction.price_per_share.toFixed(2)}
+                    {getCurrencySymbol(transaction.currency || BASE_CURRENCY)}
+                    {transaction.price_per_share.toFixed(2)}
                   </TableCell>
                   <TableCell className="text-right font-medium">
-                    ${transaction.total_value.toLocaleString()}
+                    {getCurrencySymbol(transaction.currency || BASE_CURRENCY)}
+                    {transaction.total_value.toLocaleString()}
                   </TableCell>
                   <TableCell className="text-center">
                     <AlertDialog>
@@ -115,7 +119,7 @@ function TransactionHistory({ transactions, onTransactionDeleted }) {
                             Are you sure you want to delete this transaction? This action cannot be undone.
                             <br /><br />
                             <strong>Transaction Details:</strong><br />
-                            {transaction.transaction_type.toUpperCase()} {transaction.quantity} shares of {transaction.stock_symbol} at ${transaction.price_per_share} on {new Date(transaction.transaction_date).toLocaleDateString()}
+                            {transaction.transaction_type.toUpperCase()} {transaction.quantity} shares of {transaction.stock_symbol} at {getCurrencySymbol(transaction.currency || BASE_CURRENCY)}{transaction.price_per_share} on {new Date(transaction.transaction_date).toLocaleDateString()}
                           </AlertDialogDescription>
                         </AlertDialogHeader>
                         <AlertDialogFooter>
@@ -158,7 +162,8 @@ function TransactionHistory({ transactions, onTransactionDeleted }) {
             <div>
               <p className="text-gray-600">Total Volume</p>
               <p className="font-medium">
-                ${transactions.reduce((sum, t) => sum + t.total_value, 0).toLocaleString()}
+                {getCurrencySymbol(BASE_CURRENCY)}
+                {transactions.reduce((sum, t) => sum + t.total_value, 0).toLocaleString()}
               </p>
             </div>
           </div>

--- a/portfolio-tracker/src/lib/utils.js
+++ b/portfolio-tracker/src/lib/utils.js
@@ -4,3 +4,14 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs) {
   return twMerge(clsx(inputs));
 }
+
+export function getCurrencySymbol(code) {
+  const symbols = {
+    USD: '$',
+    EUR: '€',
+    SEK: 'kr',
+    GBP: '£',
+    JPY: '¥'
+  }
+  return symbols[code] || code
+}


### PR DESCRIPTION
## Summary
- allow choosing currency when adding a transaction
- display currency symbol based on selected or base currency
- document new `VITE_BASE_CURRENCY` env var and currency field

## Testing
- `pytest -q`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b27ef81cc83308050711891875ea4