### PR TITLE
Add portfolio history chart

### DIFF
--- a/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
+++ b/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
@@ -1,0 +1,82 @@
+import { useState, useEffect } from 'react'
+import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
+import { Switch } from '@/components/ui/switch.jsx'
+
+const API_BASE_URL = import.meta.env.VITE_API_URL
+
+function PortfolioHistoryChart() {
+  const [history, setHistory] = useState([])
+  const [includeContributions, setIncludeContributions] = useState(true)
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+      try {
+        const resp = await fetch(`${API_BASE_URL}/history`)
+        if (resp.ok) {
+          const data = await resp.json()
+          setHistory(data)
+        }
+      } catch (err) {
+        console.error('Error fetching portfolio history:', err)
+      }
+    }
+
+    fetchHistory()
+  }, [])
+
+  const formatted = history.map((item) => ({
+    ...item,
+    date: new Date(item.date).toLocaleDateString()
+  }))
+
+  const lineKey = includeContributions ? 'with_contributions' : 'market_value_only'
+
+  const CustomTooltip = ({ active, payload, label }) => {
+    if (active && payload && payload.length) {
+      return (
+        <div className="bg-white p-2 border rounded shadow text-xs">
+          <p className="font-medium">{label}</p>
+          <p>${payload[0].value.toLocaleString()}</p>
+        </div>
+      )
+    }
+    return null
+  }
+
+  return (
+    <Card>
+      <CardHeader className="flex flex-row items-center justify-between">
+        <div>
+          <CardTitle>Portfolio Value</CardTitle>
+          <CardDescription>Historical portfolio value</CardDescription>
+        </div>
+        <div className="flex items-center space-x-2 text-sm">
+          <Switch
+            checked={includeContributions}
+            onCheckedChange={setIncludeContributions}
+            id="history-toggle"
+          />
+          <label htmlFor="history-toggle">
+            {includeContributions ? 'Include' : 'Exclude'} contributions
+          </label>
+        </div>
+      </CardHeader>
+      <CardContent>
+        <div className="h-80">
+          <ResponsiveContainer width="100%" height="100%">
+            <LineChart data={formatted}>
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis dataKey="date" />
+              <YAxis />
+              <Tooltip content={<CustomTooltip />} />
+              <Line type="monotone" dataKey={lineKey} stroke="#8884d8" dot={false} />
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export default PortfolioHistoryChart

--- a/portfolio-tracker/src/components/PortfolioOverview.jsx
+++ b/portfolio-tracker/src/components/PortfolioOverview.jsx
@@ -1,5 +1,6 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts'
+import PortfolioHistoryChart from './PortfolioHistoryChart'
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8', '#82CA9D', '#FFC658', '#FF7C7C']
 
@@ -77,6 +78,7 @@ function PortfolioOverview({ portfolioData, portfolioSummary }) {
 
   return (
     <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <PortfolioHistoryChart />
       {/* Portfolio Allocation */}
       <Card>
         <CardHeader>


### PR DESCRIPTION
## Summary
- implement `/api/portfolio/history` endpoint returning portfolio value history
- test the new history endpoint
- add `PortfolioHistoryChart` React component with a toggle for contributions
- display the new chart in the Overview tab

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684b2bff3b2c8330a200522fabb42bef