### PR TITLE
Add sorting toggle and improved chart labels

### DIFF
--- a/portfolio-tracker/src/components/PortfolioOverview.jsx
+++ b/portfolio-tracker/src/components/PortfolioOverview.jsx
@@ -1,6 +1,9 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { PieChart, Pie, Cell, ResponsiveContainer, BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, Legend } from 'recharts'
+import { useState } from 'react'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select.jsx'
 import PortfolioHistoryChart from './PortfolioHistoryChart'
+import { sortPerformanceData } from '@/lib/sort.js'
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8', '#82CA9D', '#FFC658', '#FF7C7C']
 
@@ -36,6 +39,10 @@ function PortfolioOverview({ portfolioData, portfolioSummary }) {
     gainPercent: stock.total_gain_percent,
     currentValue: stock.current_value
   }))
+
+  const [sortMetric, setSortMetric] = useState('current_value')
+
+  const sortedPerformanceData = sortPerformanceData(performanceData, sortMetric)
 
   const CustomTooltip = ({ active, payload }) => {
     if (active && payload && payload.length) {
@@ -94,7 +101,7 @@ function PortfolioOverview({ portfolioData, portfolioSummary }) {
                   cx="50%"
                   cy="50%"
                   labelLine={false}
-                  label={({ name, percentage }) => `${name} (${percentage}%)`}
+                  label={({ percentage }) => `${percentage}%`}
                   outerRadius={80}
                   fill="#8884d8"
                   dataKey="value"
@@ -112,24 +119,35 @@ function PortfolioOverview({ portfolioData, portfolioSummary }) {
 
       {/* Performance Chart */}
       <Card>
-        <CardHeader>
-          <CardTitle>Performance by Stock</CardTitle>
-          <CardDescription>Gain/loss for each holding</CardDescription>
+        <CardHeader className="flex flex-row items-start justify-between">
+          <div>
+            <CardTitle>Performance by Stock</CardTitle>
+            <CardDescription>Gain/loss for each holding</CardDescription>
+          </div>
+          <Select value={sortMetric} onValueChange={setSortMetric}>
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="Sort By" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="current_value">Current Value</SelectItem>
+              <SelectItem value="total_gain">Total Gain</SelectItem>
+            </SelectContent>
+          </Select>
         </CardHeader>
         <CardContent>
           <div className="h-80">
             <ResponsiveContainer width="100%" height="100%">
-              <BarChart data={performanceData}>
+              <BarChart data={sortedPerformanceData}>
                 <CartesianGrid strokeDasharray="3 3" />
                 <XAxis dataKey="symbol" />
                 <YAxis />
                 <Tooltip content={<PerformanceTooltip />} />
-                <Bar 
-                  dataKey="gain" 
+                <Bar
+                  dataKey="gain"
                   fill={(entry) => entry >= 0 ? '#10B981' : '#EF4444'}
                   name="Gain/Loss ($)"
                 >
-                  {performanceData.map((entry, index) => (
+                  {sortedPerformanceData.map((entry, index) => (
                     <Cell key={`cell-${index}`} fill={entry.gain >= 0 ? '#10B981' : '#EF4444'} />
                   ))}
                 </Bar>

--- a/portfolio-tracker/src/lib/sort.js
+++ b/portfolio-tracker/src/lib/sort.js
@@ -1,0 +1,4 @@
+export function sortPerformanceData(data, metric = 'current_value') {
+  const key = metric === 'total_gain' ? 'gain' : 'currentValue'
+  return [...data].sort((a, b) => b[key] - a[key])
+}

--- a/portfolio-tracker/tests/sort.test.js
+++ b/portfolio-tracker/tests/sort.test.js
@@ -1,0 +1,16 @@
+import assert from 'assert'
+import { sortPerformanceData } from '../src/lib/sort.js'
+
+const sample = [
+  { symbol: 'A', gain: 10, currentValue: 50 },
+  { symbol: 'B', gain: 20, currentValue: 10 },
+  { symbol: 'C', gain: -5, currentValue: 30 }
+]
+
+const byValue = sortPerformanceData(sample, 'current_value')
+assert.deepStrictEqual(byValue.map(s => s.symbol), ['A', 'C', 'B'])
+
+const byGain = sortPerformanceData(sample, 'total_gain')
+assert.deepStrictEqual(byGain.map(s => s.symbol), ['B', 'A', 'C'])
+
+console.log('All sorting tests passed.')


### PR DESCRIPTION
## Summary
- show holding percentage directly on pie chart
- add sorting select for performance bar chart
- sort bar chart by selected metric via `sortPerformanceData`
- cover sorting logic with a small test

## Testing
- `node portfolio-tracker/tests/sort.test.js`
- `pytest -q`
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_684b2f084e8c8330b82689daa5ad3c5d