### PR TITLE
Fix missing data_api module

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ BASE_CURRENCY=USD python portfolio-api/src/main.py
 If these variables are not set, the app uses default values defined in `main.py`.
 `BASE_CURRENCY` defaults to `USD`. When adding transactions in other currencies, the API fetches historical exchange rates. Set `EXCHANGE_API_KEY` if your exchange rate provider requires authentication.
 
+The backend uses a minimal `ApiClient` located in `portfolio-api/src/data_api.py` for fetching stock data. Configure `DATA_API_BASE_URL` and optionally `DATA_API_KEY` if you want to enable live price lookups.
+
 # My Portfolio
 
 This repository contains a Flask API and a React front-end for tracking investment portfolios.

--- a/portfolio-api/src/data_api.py
+++ b/portfolio-api/src/data_api.py
@@ -1,0 +1,18 @@
+import os
+import requests
+
+class ApiClient:
+    """Simple wrapper for making API requests."""
+    def __init__(self, base_url=None, api_key=None):
+        self.base_url = base_url or os.environ.get("DATA_API_BASE_URL", "")
+        self.api_key = api_key or os.environ.get("DATA_API_KEY")
+
+    def call_api(self, path, query=None):
+        """Call the remote API and return JSON response."""
+        url = self.base_url.rstrip("/") + "/" + path.lstrip("/")
+        headers = {}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        resp = requests.get(url, params=query, headers=headers, timeout=10)
+        resp.raise_for_status()
+        return resp.json()

--- a/portfolio-api/src/routes/portfolio.py
+++ b/portfolio-api/src/routes/portfolio.py
@@ -3,12 +3,9 @@ from src.models.user import db
 from src.models.portfolio import Stock, Transaction, CurrencyEnum, BASE_CURRENCY
 import requests
 from datetime import datetime, date, timedelta
-import sys
 import os
 
-# Add the API client path
-sys.path.append('/opt/.manus/.sandbox-runtime')
-from data_api import ApiClient
+from src.data_api import ApiClient
 
 portfolio_bp = Blueprint('portfolio', __name__)
 client = ApiClient()


### PR DESCRIPTION
## Summary
- add simple `ApiClient` helper in portfolio-api
- fix imports in `portfolio.py`
- document DATA_API env vars

## Testing
- `pip install -r portfolio-api/requirements.txt`
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b35562338833091d3a42430c3d634