### PR TITLE
Fix SQLite path for consistent startup

### DIFF
--- a/portfolio-api/src/config.py
+++ b/portfolio-api/src/config.py
@@ -1,0 +1,8 @@
+from pathlib import Path
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+SQLALCHEMY_DATABASE_URI = f"sqlite:///{BASE_DIR}/data/portfolio.db"
+
+# Ensure the parent directory for the SQLite file exists
+_db_path = Path(SQLALCHEMY_DATABASE_URI.replace("sqlite:///", ""))
+_db_path.parent.mkdir(parents=True, exist_ok=True)

--- a/portfolio-api/src/main.py
+++ b/portfolio-api/src/main.py
@@ -9,6 +9,7 @@ from src.models.user import db
 from src.models.portfolio import Stock, Transaction
 from src.routes.user import user_bp
 from src.routes.portfolio import portfolio_bp
+from src.config import SQLALCHEMY_DATABASE_URI
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
 # Allow SECRET_KEY to be configured via environment variable for flexibility
@@ -22,8 +23,7 @@ app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(portfolio_bp, url_prefix='/api/portfolio')
 
 # uncomment if you need to use database
-default_db = f"sqlite:///{os.path.join(os.path.dirname(__file__), 'database', 'app.db')}"
-app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', default_db)
+app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', SQLALCHEMY_DATABASE_URI)
 app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 db.init_app(app)
 with app.app_context():


### PR DESCRIPTION
## Summary
- compute project base directory in `config.py`
- auto-create `data/` folder on startup to avoid missing path errors
- update `main.py` to use the new constant
- tests remain green

## Testing
- `pytest -q`
- `uvicorn portfolio-api.src.main:app --port 8001 --reload`

------
https://chatgpt.com/codex/tasks/task_e_684b37db7e7c833085f5c25e10a39e8e