### PR TITLE
Add Google-Finance Copy-Paste Import

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,13 @@ The HTML page used for quick testing of these endpoints has been moved to
 3. Call the API directly (e.g., using `curl` or Postman) to integrate with other tools.
 4. Update prices periodically using the "Update Prices" button or the corresponding API endpoint.
 
+## Import trades
+
+Paste your Google Finance activity text directly into the app.
+Open the **Import ▸ Google Finance** dialog on the Transactions page, preview the
+parsed rows and confirm to save them. Save the confirmed rows to your portfolio
+with the **Confirm & Save** button.
+
 ## Running Tests
 
 Install the test requirements and run pytest:

--- a/portfolio-api/src/main.py
+++ b/portfolio-api/src/main.py
@@ -9,6 +9,7 @@ from src.models.user import db
 from src.models.portfolio import Stock, Transaction
 from src.routes.user import user_bp
 from src.routes.portfolio import portfolio_bp
+from src.routes.import_routes import import_bp
 from src.config import SQLALCHEMY_DATABASE_URI
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
@@ -21,6 +22,7 @@ CORS(app)
 
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(portfolio_bp, url_prefix='/api/portfolio')
+app.register_blueprint(import_bp, url_prefix='/api/import')
 
 # uncomment if you need to use database
 app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', SQLALCHEMY_DATABASE_URI)

--- a/portfolio-api/src/routes/import_routes.py
+++ b/portfolio-api/src/routes/import_routes.py
@@ -1,0 +1,129 @@
+import re
+from datetime import datetime
+from flask import Blueprint, request, jsonify
+from src.models.portfolio import Stock, Transaction, CurrencyEnum
+from src.models.user import db
+
+import_bp = Blueprint('import', __name__)
+
+HEADER_RE = re.compile(r"^(?P<ticker>[A-Z]{2,5})\s+(?P<side>purchase|sale)$", re.I)
+DETAIL_RE = re.compile(
+    r"^(?P<date>\d{1,2}/\d{1,2}/\d{4})\s+(?P<shares>[\d.,]+)\s+shares?\s+(?:@|at)\s+[€$]?(?P<price>[\d.,]+)",
+    re.I,
+)
+
+
+def _parse_number(text: str) -> float | None:
+    clean = text.replace("\u202f", "").replace(" ", "")
+    clean = clean.replace("€", "").replace("$", "")
+    if clean.count(",") > 0 and clean.count(".") > 0:
+        if clean.rfind(",") > clean.rfind("."):
+            clean = clean.replace(".", "").replace(",", ".")
+        else:
+            clean = clean.replace(",", "")
+    elif clean.count(",") > 0:
+        clean = clean.replace(",", ".")
+    try:
+        return float(clean)
+    except ValueError:
+        return None
+
+
+def _parse_block(lines):
+    if len(lines) < 3:
+        return None
+    m1 = HEADER_RE.match(lines[0])
+    if not m1:
+        return None
+    m2 = DETAIL_RE.match(lines[2])
+    if not m2:
+        return None
+    amount = _parse_number(lines[1])
+    date_str = m2.group("date")
+    try:
+        date = datetime.strptime(date_str, "%d/%m/%Y").date()
+    except ValueError:
+        return None
+    shares = _parse_number(m2.group("shares"))
+    price = _parse_number(m2.group("price"))
+    currency = "USD"
+    if "€" in lines[1] or "€" in lines[2]:
+        currency = "EUR"
+    row = {
+        "ticker": m1.group("ticker").upper(),
+        "action": m1.group("side").lower(),
+        "date": date.isoformat(),
+        "shares": shares,
+        "price": price,
+        "amount": round((shares or 0) * (price or 0), 2),
+        "currency": currency,
+    }
+    if None in row.values():
+        return None
+    return row
+
+
+def _parse_raw(raw: str):
+    lines = [ln.strip() for ln in raw.splitlines() if ln.strip()]
+    rows = []
+    invalid = []
+    i = 0
+    while i < len(lines):
+        chunk = lines[i:i+3]
+        row = _parse_block(chunk)
+        if row:
+            rows.append(row)
+            i += 3
+        else:
+            invalid.append(lines[i])
+            i += 1
+    return rows, invalid
+
+
+@import_bp.route('/google-finance/preview', methods=['POST'])
+def google_finance_preview():
+    data = request.get_json(force=True)
+    raw = data.get('raw', '')
+    rows, invalid = _parse_raw(raw)
+    return jsonify({"rows": rows, "invalid_rows": invalid})
+
+
+@import_bp.route('/google-finance', methods=['POST'])
+def google_finance_import():
+    data = request.get_json(force=True)
+    raw = data.get('raw', '')
+    rows, invalid = _parse_raw(raw)
+    ids = []
+    duplicates = 0
+    for row in rows:
+        side = 'buy' if row['action'] == 'purchase' else 'sell'
+        date_obj = datetime.strptime(row['date'], '%Y-%m-%d').date()
+        stock = Stock.query.filter_by(symbol=row['ticker']).first()
+        if not stock:
+            stock = Stock(symbol=row['ticker'])
+            db.session.add(stock)
+            db.session.flush()
+        exists = Transaction.query.join(Stock).filter(
+            Stock.symbol == row['ticker'],
+            Transaction.transaction_type == side,
+            Transaction.transaction_date == date_obj,
+            Transaction.quantity == int(row['shares']),
+            Transaction.price_per_share == float(row['price']),
+        ).first()
+        if exists:
+            duplicates += 1
+            continue
+        tx = Transaction(
+            stock_id=stock.id,
+            transaction_type=side,
+            quantity=int(row['shares']),
+            price_per_share=float(row['price']),
+            currency=CurrencyEnum[row['currency']],
+            fx_rate=1.0,
+            transaction_date=date_obj,
+        )
+        db.session.add(tx)
+        db.session.flush()
+        ids.append(tx.id)
+    db.session.commit()
+    return jsonify({"inserted_ids": ids, "invalid_rows": invalid, "duplicates_skipped": duplicates})

--- a/portfolio-api/tests/conftest.py
+++ b/portfolio-api/tests/conftest.py
@@ -11,6 +11,7 @@ from flask import Flask
 from src.models.user import db
 from src.routes.user import user_bp
 from src.routes.portfolio import portfolio_bp
+from src.routes.import_routes import import_bp
 
 @pytest.fixture
 def app():
@@ -24,6 +25,7 @@ def app():
         db.create_all()
     app.register_blueprint(user_bp, url_prefix='/api')
     app.register_blueprint(portfolio_bp, url_prefix='/api/portfolio')
+    app.register_blueprint(import_bp, url_prefix='/api/import')
     yield app
 
 @pytest.fixture

--- a/portfolio-api/tests/test_import_google.py
+++ b/portfolio-api/tests/test_import_google.py
@@ -1,0 +1,52 @@
+import json
+from datetime import date
+
+def sample_raw():
+    return """AAPL purchase
+$200.00
+01/05/2024 2 shares @ $100.00
+
+MSFT sale
+€300,00
+02/05/2024 3 shares @ €100,00
+
+BADLINE"""
+
+
+def test_preview_parses_rows(client):
+    resp = client.post('/api/import/google-finance/preview', json={'raw': sample_raw()})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data['rows']) == 2
+    first = data['rows'][0]
+    assert first['ticker'] == 'AAPL'
+    assert first['action'] == 'purchase'
+    assert first['shares'] == 2
+    assert first['price'] == 100.0
+
+
+def test_import_creates_transactions(client, app):
+    resp = client.post('/api/import/google-finance', json={'raw': sample_raw()})
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body['inserted_ids']) == 2
+    assert body['duplicates_skipped'] == 0
+
+    # second call should skip duplicates
+    resp2 = client.post('/api/import/google-finance', json={'raw': sample_raw()})
+    assert resp2.status_code == 200
+    body2 = resp2.get_json()
+    assert body2['duplicates_skipped'] == 2
+
+    with app.app_context():
+        from src.models.portfolio import Transaction
+        assert Transaction.query.count() == 2
+
+
+def test_invalid_lines_returned(client):
+    raw = "BAD purchase\n123\nmissing details"
+    resp = client.post('/api/import/google-finance/preview', json={'raw': raw})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['rows'] == []
+    assert len(data['invalid_rows']) >= 1

--- a/portfolio-tracker/src/components/ImportDialog.tsx
+++ b/portfolio-tracker/src/components/ImportDialog.tsx
@@ -1,0 +1,122 @@
+import { useState } from 'react'
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog.jsx'
+import { Button } from '@/components/ui/button.jsx'
+import { Textarea } from '@/components/ui/textarea.jsx'
+import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@/components/ui/table.jsx'
+import { Alert, AlertDescription } from '@/components/ui/alert.jsx'
+import { parseGoogleFinance, importGoogleFinance } from '@/lib/api'
+import { toast } from 'sonner'
+
+interface ImportDialogProps {
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onImported: () => void
+}
+
+export default function ImportDialog({ open, onOpenChange, onImported }: ImportDialogProps) {
+  const [raw, setRaw] = useState('')
+  const [rows, setRows] = useState<any[]>([])
+  const [invalid, setInvalid] = useState<string[]>([])
+  const [loading, setLoading] = useState(false)
+  const [step, setStep] = useState<'idle' | 'preview'>('idle')
+
+  const handleParse = async () => {
+    setLoading(true)
+    try {
+      const res = await parseGoogleFinance(raw)
+      setRows(res.rows || [])
+      setInvalid(res.invalid_rows || [])
+      setStep('preview')
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleImport = async () => {
+    setLoading(true)
+    try {
+      const res = await importGoogleFinance(raw)
+      if (res.duplicates_skipped) {
+        toast.success(`Skipped ${res.duplicates_skipped} duplicates`)
+      }
+      onImported()
+      onOpenChange(false)
+    } catch (e) {
+      console.error(e)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleClose = () => {
+    setRaw('')
+    setRows([])
+    setInvalid([])
+    setStep('idle')
+    onOpenChange(false)
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleClose}>
+      <DialogContent className="max-w-3xl">
+        <DialogHeader>
+          <DialogTitle>Import from Google Finance</DialogTitle>
+        </DialogHeader>
+        {step === 'idle' && (
+          <div className="space-y-4">
+            <Textarea
+              value={raw}
+              onChange={(e) => setRaw(e.target.value)}
+              placeholder="Paste the activity text here"
+              className="h-40"
+            />
+            <Button onClick={handleParse} disabled={loading || !raw.trim()}>Parse</Button>
+          </div>
+        )}
+        {step === 'preview' && (
+          <div className="space-y-4">
+            {invalid.length > 0 && (
+              <Alert variant="destructive">
+                <AlertDescription>
+                  {invalid.length} invalid lines ignored
+                </AlertDescription>
+              </Alert>
+            )}
+            <div className="max-h-64 overflow-auto border rounded">
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Ticker</TableHead>
+                    <TableHead>Action</TableHead>
+                    <TableHead>Date</TableHead>
+                    <TableHead className="text-right">Shares</TableHead>
+                    <TableHead className="text-right">Price</TableHead>
+                    <TableHead className="text-right">Amount</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {rows.map((r, idx) => (
+                    <TableRow key={idx}>
+                      <TableCell>{r.ticker}</TableCell>
+                      <TableCell>{r.action}</TableCell>
+                      <TableCell>{new Date(r.date).toLocaleDateString()}</TableCell>
+                      <TableCell className="text-right">{r.shares}</TableCell>
+                      <TableCell className="text-right">{r.price}</TableCell>
+                      <TableCell className="text-right">{r.amount}</TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </div>
+            <DialogFooter>
+              <Button variant="outline" onClick={() => setStep('idle')}>Back</Button>
+              <Button onClick={handleImport} disabled={loading}>Confirm & Save</Button>
+            </DialogFooter>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/portfolio-tracker/src/lib/api.ts
+++ b/portfolio-tracker/src/lib/api.ts
@@ -1,0 +1,21 @@
+const BASE = import.meta.env.VITE_API_URL.replace(/\/portfolio$/, '')
+
+export async function parseGoogleFinance(raw: string) {
+  const resp = await fetch(`${BASE}/import/google-finance/preview`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ raw })
+  })
+  if (!resp.ok) throw new Error('Failed to parse')
+  return resp.json()
+}
+
+export async function importGoogleFinance(raw: string) {
+  const resp = await fetch(`${BASE}/import/google-finance`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ raw })
+  })
+  if (!resp.ok) throw new Error('Failed to import')
+  return resp.json()
+}

--- a/portfolio-tracker/src/pages/Transactions.tsx
+++ b/portfolio-tracker/src/pages/Transactions.tsx
@@ -1,0 +1,47 @@
+import { useState, useEffect } from 'react'
+import TransactionHistory from '@/components/TransactionHistory'
+import AddTransactionModal from '@/components/AddTransactionModal'
+import ImportDialog from '@/components/ImportDialog'
+import { Button } from '@/components/ui/button.jsx'
+
+const API_BASE_URL = import.meta.env.VITE_API_URL
+
+export default function TransactionsPage() {
+  const [transactions, setTransactions] = useState([])
+  const [showAdd, setShowAdd] = useState(false)
+  const [showImport, setShowImport] = useState(false)
+
+  const fetchTransactions = async () => {
+    const resp = await fetch(`${API_BASE_URL}/transactions`)
+    if (resp.ok) setTransactions(await resp.json())
+  }
+
+  useEffect(() => {
+    fetchTransactions()
+  }, [])
+
+  return (
+    <div className="space-y-4">
+      <div className="flex justify-end gap-2">
+        <Button onClick={() => setShowImport(true)} variant="outline">
+          Import ▸ Google Finance
+        </Button>
+        <Button onClick={() => setShowAdd(true)}>Add Transaction</Button>
+      </div>
+      <TransactionHistory
+        transactions={transactions}
+        onTransactionDeleted={fetchTransactions}
+      />
+      <AddTransactionModal
+        isOpen={showAdd}
+        onClose={() => setShowAdd(false)}
+        onTransactionAdded={fetchTransactions}
+      />
+      <ImportDialog
+        open={showImport}
+        onOpenChange={setShowImport}
+        onImported={fetchTransactions}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- allow pasting Google Finance activity text and parse to transactions
- add import API routes with preview and deduplication
- provide React ImportDialog and new Transactions page
- document import flow
- remove binary screenshot

## Testing
- `pytest -q`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b3fdfdfc88330b5bf71ef7b6e219d