### PR TITLE
Add version footer to frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ pip install -r requirements.txt
 uvicorn src.main:app --reload
 ```
 
+Each build stamps the current commit hash into the app. The footer will display
+the version like `v4e96b97` corresponding to the commit used for the build.
+
 The API reads optional environment variables like `SECRET_KEY`, `DATABASE_URL` and `BASE_CURRENCY`. Default values are provided so it will start without extra configuration. Historical price lookups use the minimal `ApiClient` in `portfolio-api/src/data_api.py`.
 
 # My Portfolio

--- a/portfolio-tracker/package-lock.json
+++ b/portfolio-tracker/package-lock.json
@@ -63,6 +63,7 @@
         "@types/react": "^19.1.2",
         "@types/react-dom": "^19.1.2",
         "@vitejs/plugin-react": "^4.4.1",
+        "cross-env": "^7.0.3",
         "eslint": "^9.25.0",
         "eslint-plugin-react-hooks": "^5.2.0",
         "eslint-plugin-react-refresh": "^0.4.19",
@@ -3403,6 +3404,25 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/portfolio-tracker/package.json
+++ b/portfolio-tracker/package.json
@@ -4,8 +4,8 @@
   "version": "0.0.0",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "vite build",
+    "dev": "cross-env VITE_APP_VERSION=$(git rev-parse --short HEAD) vite",
+    "build": "cross-env VITE_APP_VERSION=$(git rev-parse --short HEAD) vite build",
     "lint": "eslint .",
     "preview": "vite preview"
   },
@@ -65,6 +65,7 @@
     "@types/react": "^19.1.2",
     "@types/react-dom": "^19.1.2",
     "@vitejs/plugin-react": "^4.4.1",
+    "cross-env": "^7.0.3",
     "eslint": "^9.25.0",
     "eslint-plugin-react-hooks": "^5.2.0",
     "eslint-plugin-react-refresh": "^0.4.19",

--- a/portfolio-tracker/src/App.jsx
+++ b/portfolio-tracker/src/App.jsx
@@ -8,6 +8,7 @@ import PortfolioOverview from './components/PortfolioOverview'
 import StockHoldings from './components/StockHoldings'
 import TransactionHistory from './components/TransactionHistory'
 import AddTransactionModal from './components/AddTransactionModal'
+import Footer from './components/Footer'
 import './App.css'
 
 const API_BASE_URL = import.meta.env.VITE_API_URL
@@ -224,6 +225,7 @@ function App() {
           onClose={() => setIsAddTransactionOpen(false)}
           onTransactionAdded={handleTransactionAdded}
         />
+        <Footer />
       </div>
     </div>
   )

--- a/portfolio-tracker/src/components/Footer.tsx
+++ b/portfolio-tracker/src/components/Footer.tsx
@@ -1,0 +1,11 @@
+import React from 'react'
+
+const version = import.meta.env.VITE_APP_VERSION
+
+export default function Footer() {
+  return (
+    <footer className="text-center text-xs text-muted-foreground py-6">
+      v{version}
+    </footer>
+  )
+}


### PR DESCRIPTION
## Summary
- display current commit in footer of portfolio-tracker
- expose build version via VITE_APP_VERSION
- use cross-env in scripts to populate version
- mention build commit stamping in docs

## Testing
- `node portfolio-tracker/tests/sort.test.js`
- `pytest -q`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_684bccf942888330a065841f50725d45