### PR TITLE
Update API base URL handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository contains a Flask backend (`portfolio-api`) and a React frontend 
 
 ## Environment Variables
 
-The front-end uses Vite environment variables. Copy `.env.example` in `portfolio-tracker` to `.env` and update the values as needed.
+The front-end uses Vite environment variables. Copy `.env.local.example` in `portfolio-tracker` to `.env.local` and update the values as needed.
 
 ```
 VITE_API_URL=http://localhost:5000/api/portfolio
@@ -20,7 +20,7 @@ This project requires **Node.js 20** and **Python 3.11+**.
 
 ```bash
 # frontend
-cd portfolio-tracker && npm install && npm run build
+cd portfolio-tracker && cp .env.local.example .env.local && npm install && npm run dev
 
 # backend
 cd ../portfolio-api

--- a/portfolio-tracker/.env.local.example
+++ b/portfolio-tracker/.env.local.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/portfolio-tracker/jest.config.cjs
+++ b/portfolio-tracker/jest.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
   moduleNameMapper: {
     '^@/(.*)$': '<rootDir>/src/$1'
   },
+  setupFiles: ['<rootDir>/tests/setup-env.js'],
   setupFilesAfterEnv: ['<rootDir>/tests/setup-tests.js'],
   testMatch: ['<rootDir>/tests/**/*.test.{js,ts,jsx,tsx}'],
   extensionsToTreatAsEsm: ['.ts', '.tsx', '.jsx'],

--- a/portfolio-tracker/src/components/Footer.tsx
+++ b/portfolio-tracker/src/components/Footer.tsx
@@ -1,11 +1,12 @@
 import React from 'react'
+import { API_BASE_URL } from '@/lib/api'
 
 const version = import.meta.env.VITE_APP_VERSION
 
 export default function Footer() {
   return (
     <footer className="text-center text-xs text-muted-foreground py-6">
-      v{version}
+      v{version} · {API_BASE_URL}
     </footer>
   )
 }

--- a/portfolio-tracker/src/lib/api.ts
+++ b/portfolio-tracker/src/lib/api.ts
@@ -1,21 +1,22 @@
-const BASE = (import.meta?.env?.VITE_API_URL || '').replace(/\/portfolio$/, '')
+export const API_BASE_URL =
+  import.meta.env?.VITE_API_URL?.replace(/\/+$/, '') || window.location.origin
+
+export const get = (url: string) => fetch(`${API_BASE_URL}${url}`)
+export const post = (url: string, body: any) =>
+  fetch(`${API_BASE_URL}${url}`, {
+    method: 'POST',
+    body: JSON.stringify(body),
+    headers: { 'Content-Type': 'application/json' }
+  })
 
 export async function parseGoogleFinance(raw: string) {
-  const resp = await fetch(`${BASE}/import/google-finance/preview`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ raw })
-  })
+  const resp = await post('/import/google-finance/preview', { raw })
   if (!resp.ok) throw new Error('Failed to parse')
   return resp.json()
 }
 
 export async function importGoogleFinance(raw: string) {
-  const resp = await fetch(`${BASE}/import/google-finance`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ raw })
-  })
+  const resp = await post('/import/google-finance', { raw })
   if (!resp.ok) throw new Error('Failed to import')
   return resp.json()
 }

--- a/portfolio-tracker/tests/setup-env.js
+++ b/portfolio-tracker/tests/setup-env.js
@@ -1,0 +1,3 @@
+if (typeof window !== 'undefined') {
+  window.location.assign('http://localhost');
+}


### PR DESCRIPTION
## Summary
- default API base URL to the current origin when `VITE_API_URL` is absent
- display base URL in app footer
- document new `.env.local.example`
- update Jest config to mock `window.location` before tests
- adjust quick-start instructions

## Testing
- `npm test --silent` in `portfolio-tracker`
- `pytest -q` in `portfolio-api`


------
https://chatgpt.com/codex/tasks/task_e_684c2f94b93483309005004cd8f59b03