### PR TITLE
Align API base and use helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository contains a Flask backend (`portfolio-api`) and a React frontend 
 The front-end uses Vite environment variables. Copy `.env.local.example` in `portfolio-tracker` to `.env.local` and update the values as needed.
 
 ```
-VITE_API_URL=http://localhost:5000/api/portfolio
+VITE_API_URL=http://localhost:8000/api
 VITE_BASE_CURRENCY=USD
 ```
 

--- a/portfolio-tracker/.env.local.example
+++ b/portfolio-tracker/.env.local.example
@@ -1,1 +1,1 @@
-VITE_API_URL=http://localhost:8000
+VITE_API_URL=http://localhost:8000/api

--- a/portfolio-tracker/src/App.jsx
+++ b/portfolio-tracker/src/App.jsx
@@ -9,8 +9,7 @@ import StockHoldings from './components/StockHoldings'
 import TransactionHistory from './components/TransactionHistory'
 import Footer from './components/Footer'
 import './App.css'
-
-const API_BASE_URL = import.meta.env.VITE_API_URL
+import { get, post } from '@/lib/api'
 
 function App() {
   const [portfolioData, setPortfolioData] = useState([])
@@ -22,9 +21,9 @@ function App() {
     try {
       setLoading(true)
       const [stocksResponse, summaryResponse, transactionsResponse] = await Promise.all([
-        fetch(`${API_BASE_URL}/stocks`),
-        fetch(`${API_BASE_URL}/portfolio/summary`),
-        fetch(`${API_BASE_URL}/transactions`)
+        get('/stocks'),
+        get('/portfolio/summary'),
+        get('/transactions')
       ])
 
       if (stocksResponse.ok) {
@@ -52,9 +51,7 @@ function App() {
     try {
       setLoading(true)
       for (const stock of portfolioData) {
-        await fetch(`${API_BASE_URL}/stocks/${stock.symbol}/price`, {
-          method: 'POST'
-        })
+        await post(`/stocks/${stock.symbol}/price`, {})
       }
       await fetchPortfolioData()
     } catch (error) {

--- a/portfolio-tracker/src/components/AddTransactionModal.jsx
+++ b/portfolio-tracker/src/components/AddTransactionModal.jsx
@@ -7,8 +7,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { Alert, AlertDescription } from '@/components/ui/alert.jsx'
 import { Loader2, Search } from 'lucide-react'
 import { getCurrencySymbol } from '@/lib/utils.js'
+import { get, post } from '@/lib/api'
 
-const API_BASE_URL = import.meta?.env?.VITE_API_URL || ''
 const BASE_CURRENCY = import.meta?.env?.VITE_BASE_CURRENCY || 'USD'
 
 function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
@@ -35,7 +35,7 @@ function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
 
     const timeoutId = setTimeout(async () => {
       try {
-        const res = await fetch(`${API_BASE_URL}/stocks/search/${query}`)
+        const res = await get(`/stocks/search/${query}`)
         if (res.ok) {
           const data = await res.json()
           setSuggestions(Array.isArray(data) ? data : [data])
@@ -68,7 +68,7 @@ function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
       setSearchingStock(true)
       setError('')
       
-      const response = await fetch(`${API_BASE_URL}/stocks/search/${searchSymbol}`)
+      const response = await get(`/stocks/search/${searchSymbol}`)
       
       if (response.ok) {
         const stockData = await response.json()
@@ -129,18 +129,12 @@ function AddTransactionModal({ isOpen, onClose, onTransactionAdded }) {
       setLoading(true)
       setError('')
       
-      const response = await fetch(`${API_BASE_URL}/transactions`, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json'
-        },
-        body: JSON.stringify({
-          ...formData,
-          symbol: formData.symbol.trim().toUpperCase(),
-          quantity: parseInt(formData.quantity),
-          price_per_share: parseFloat(formData.price_per_share),
-          currency: formData.currency
-        })
+      const response = await post('/transactions', {
+        ...formData,
+        symbol: formData.symbol.trim().toUpperCase(),
+        quantity: parseInt(formData.quantity),
+        price_per_share: parseFloat(formData.price_per_share),
+        currency: formData.currency
       })
       
       if (response.ok) {

--- a/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
+++ b/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
@@ -2,8 +2,7 @@ import { useState, useEffect } from 'react'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Switch } from '@/components/ui/switch.jsx'
-
-const API_BASE_URL = import.meta.env.VITE_API_URL
+import { get } from '@/lib/api'
 
 function PortfolioHistoryChart() {
   const [history, setHistory] = useState([])
@@ -12,7 +11,7 @@ function PortfolioHistoryChart() {
   useEffect(() => {
     const fetchHistory = async () => {
       try {
-        const resp = await fetch(`${API_BASE_URL}/history`)
+        const resp = await get('/history')
         if (resp.ok) {
           const data = await resp.json()
           setHistory(data)

--- a/portfolio-tracker/src/components/StockHoldings.jsx
+++ b/portfolio-tracker/src/components/StockHoldings.jsx
@@ -5,8 +5,8 @@ import { Badge } from '@/components/ui/badge.jsx'
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table.jsx'
 import { TrendingUp, TrendingDown, RefreshCw, ExternalLink } from 'lucide-react'
 import { getCurrencySymbol } from '@/lib/utils.js'
+import { post } from '@/lib/api'
 
-const API_BASE_URL = import.meta.env.VITE_API_URL
 const BASE_CURRENCY = import.meta.env.VITE_BASE_CURRENCY || 'USD'
 
 function StockHoldings({ portfolioData, onRefresh, loading }) {
@@ -15,9 +15,7 @@ function StockHoldings({ portfolioData, onRefresh, loading }) {
   const updateSingleStockPrice = async (symbol) => {
     try {
       setUpdatingStock(symbol)
-      const response = await fetch(`${API_BASE_URL}/stocks/${symbol}/price`, {
-        method: 'POST'
-      })
+      const response = await post(`/stocks/${symbol}/price`, {})
       
       if (response.ok) {
         onRefresh()

--- a/portfolio-tracker/src/components/TransactionHistory.jsx
+++ b/portfolio-tracker/src/components/TransactionHistory.jsx
@@ -8,8 +8,7 @@ import { Trash2, TrendingUp, TrendingDown } from 'lucide-react'
 import { getCurrencySymbol } from '@/lib/utils.js'
 import ImportDialog from '@/components/ImportDialog'
 import AddTransactionButton from '@/components/AddTransactionButton'
-
-const API_BASE_URL = import.meta?.env?.VITE_API_URL || ''
+import { API_BASE_URL } from '@/lib/api'
 const BASE_CURRENCY = import.meta?.env?.VITE_BASE_CURRENCY || 'USD'
 
 function TransactionHistory({ transactions, onTransactionDeleted, onTransactionAdded }) {

--- a/portfolio-tracker/tests/setup-env.js
+++ b/portfolio-tracker/tests/setup-env.js
@@ -1,3 +1,5 @@
 if (typeof window !== 'undefined') {
   window.location.assign('http://localhost');
 }
+
+process.env.VITE_API_URL = 'http://localhost/api';


### PR DESCRIPTION
## Summary
- sync env example for new API base
- centralize API calls on helper
- import API base in TransactionHistory
- mock VITE_API_URL in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684c31e3ea848330976f6f81e0d1f67d