### PR TITLE
Enable CORS for all API routes

### DIFF
--- a/portfolio-api/src/main.py
+++ b/portfolio-api/src/main.py
@@ -13,12 +13,11 @@ from src.routes.import_routes import import_bp
 from src.config import SQLALCHEMY_DATABASE_URI
 
 app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
+# Enable CORS for all API routes
+CORS(app, resources={r"/api/*": {"origins": "*"}})
 # Allow SECRET_KEY to be configured via environment variable for flexibility
 app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'asdf#FGSgvasgf$5$WGT')
 app.config['BASE_CURRENCY'] = os.environ.get('BASE_CURRENCY', 'USD')
-
-# Enable CORS for all API routes
-CORS(app, resources={r"/api/*": {"origins": "*"}})
 
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(portfolio_bp, url_prefix='/api/portfolio')

--- a/portfolio-api/tests/test_portfolio_endpoints.py
+++ b/portfolio-api/tests/test_portfolio_endpoints.py
@@ -74,7 +74,7 @@ def test_currency_conversion(client, monkeypatch):
     client.post('/api/portfolio/transactions', json=usd)
     client.post('/api/portfolio/transactions', json=eur)
 
-    summary = client.get('/api/portfolio/portfolio/summary')
+    summary = client.get('/api/portfolio/summary')
     assert summary.status_code == 200
     data = summary.get_json()
     assert round(data['total_cost_basis'], 2) == 220.0


### PR DESCRIPTION
## Summary
- ensure CORS setup happens immediately after creating the Flask app
- fix broken portfolio summary test path

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684c77df04608330a0e021652ae84da2