### PR TITLE
fix(frontend): remove double “/portfolio/” segment in API URLs

### DIFF
--- a/portfolio-tracker/src/App.jsx
+++ b/portfolio-tracker/src/App.jsx
@@ -9,7 +9,7 @@ import StockHoldings from './components/StockHoldings'
 import TransactionHistory from './components/TransactionHistory'
 import Footer from './components/Footer'
 import './App.css'
-import { getStocks, getSummary, getTransactions, post } from '@/lib/api'
+import { fetchStocks, fetchSummary, fetchTransactions, post } from '@/lib/api'
 
 function App() {
   const [portfolioData, setPortfolioData] = useState([])
@@ -20,10 +20,16 @@ function App() {
   const fetchPortfolioData = async () => {
     try {
       setLoading(true)
+      const [stocksResp, summaryResp, transactionsResp] = await Promise.all([
+        fetchStocks(),
+        fetchSummary(),
+        fetchTransactions()
+      ])
+
       const [stocks, summary, transactions] = await Promise.all([
-        getStocks(),
-        getSummary(),
-        getTransactions()
+        stocksResp.json(),
+        summaryResp.json(),
+        transactionsResp.json()
       ])
 
       setPortfolioData(stocks)

--- a/portfolio-tracker/src/lib/api.ts
+++ b/portfolio-tracker/src/lib/api.ts
@@ -1,27 +1,27 @@
 const env = (typeof import.meta !== 'undefined' && (import.meta as any).env) ||
   (process.env as any)
 
-const API = env.VITE_PORTFOLIO_API ?? ''
-const IMPORT_API = env.VITE_IMPORT_API ?? API
+export const BASE = (env.VITE_PORTFOLIO_API ?? '').replace(/\/$/, '')
+const IMPORT_API = env.VITE_IMPORT_API ?? BASE
 
-export const API_BASE_URL = API
+export const API_BASE_URL = BASE
 
-export const get = (path: string) => fetch(`${API}${path}`)
+export const get = (path: string) => fetch(`${BASE}${path}`)
 export const post = (path: string, body: any) =>
-  fetch(`${API}${path}`, {
+  fetch(`${BASE}${path}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)
   })
-export const del = (path: string) => fetch(`${API}${path}`, { method: 'DELETE' })
+export const del = (path: string) => fetch(`${BASE}${path}`, { method: 'DELETE' })
 
-export const getStocks = () => fetch(`${API}/stocks`).then(r => r.json())
-export const getSummary = () => fetch(`${API}/portfolio/summary`).then(r => r.json())
-export const getTransactions = () => fetch(`${API}/transactions`).then(r => r.json())
+export const fetchStocks = () => fetch(`${BASE}/stocks`)
+export const fetchSummary = () => fetch(`${BASE}/summary`)
+export const fetchTransactions = () => fetch(`${BASE}/transactions`)
 export const searchStock = (s: string) =>
-  fetch(`${API}/stocks/search/${encodeURIComponent(s)}`).then(r => r.json())
+  fetch(`${BASE}/stocks/search/${encodeURIComponent(s)}`)
 export const addTransaction = (body: any) =>
-  fetch(`${API}/transactions`, {
+  fetch(`${BASE}/transactions`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body)

--- a/portfolio-tracker/tests/api.test.ts
+++ b/portfolio-tracker/tests/api.test.ts
@@ -1,23 +1,23 @@
 import { jest } from '@jest/globals'
 
 beforeEach(() => {
+  import.meta.env = { VITE_PORTFOLIO_API: 'http://localhost:1234/api/portfolio' }
   process.env.VITE_PORTFOLIO_API = 'http://localhost:1234/api/portfolio'
-  process.env.VITE_IMPORT_API = 'http://localhost:1234/api/import'
   global.fetch = jest.fn(() =>
-    Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    Promise.resolve({ ok: true })
   ) as any
 })
 
 afterEach(() => {
+  delete import.meta.env
   delete process.env.VITE_PORTFOLIO_API
-  delete process.env.VITE_IMPORT_API
   ;(global.fetch as any).mockReset()
 })
 
-test('getSummary uses portfolio API base', async () => {
-  const { getSummary } = await import('../src/lib/api')
-  await getSummary()
+test('fetchSummary uses portfolio API base', async () => {
+  const { fetchSummary } = await import('../src/lib/api')
+  await fetchSummary()
   expect(global.fetch).toHaveBeenCalledWith(
-    'http://localhost:1234/api/portfolio/portfolio/summary'
+    'http://localhost:1234/api/portfolio/summary'
   )
 })


### PR DESCRIPTION
## Summary
- simplify API base URL handling in `api.ts`
- update App and AddTransactionModal to work with new fetch helpers
- adjust API unit test to use the new helpers

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684d35101b4883308acfbcc2dabc7021