### PR TITLE
Update frontend API env var

### DIFF
--- a/portfolio-tracker/.env.example
+++ b/portfolio-tracker/.env.example
@@ -1,2 +1,2 @@
-VITE_API_URL=http://localhost:5000/api/portfolio
+VITE_PORTFOLIO_API=http://localhost:5000/api/portfolio
 VITE_BASE_CURRENCY=USD

--- a/portfolio-tracker/.env.local.example
+++ b/portfolio-tracker/.env.local.example
@@ -1,3 +1,2 @@
 VITE_PORTFOLIO_API=http://localhost:8000/api/portfolio
 VITE_IMPORT_API=http://localhost:8000/api/import
-VITE_API_URL=http://localhost:8000/api

--- a/portfolio-tracker/tests/health.spec.ts
+++ b/portfolio-tracker/tests/health.spec.ts
@@ -1,0 +1,28 @@
+import React from 'react'
+import { render, waitFor } from '@testing-library/react'
+import { jest } from '@jest/globals'
+import App from '../src/App'
+
+beforeEach(() => {
+  // simulate environment variables used by the api helper
+  window.process = { env: { VITE_PORTFOLIO_API: 'http://test' } } as any
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve([]) })
+  ) as any
+})
+
+afterEach(() => {
+  // cleanup mocked objects
+  delete (window as any).process
+  ;(global.fetch as any).mockReset()
+})
+
+test('App fetches data from configured API base', async () => {
+  render(<App />)
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+
+  expect(global.fetch).toHaveBeenCalledWith('http://test/stocks')
+  expect(global.fetch).toHaveBeenCalledWith('http://test/portfolio/summary')
+  expect(global.fetch).toHaveBeenCalledWith('http://test/transactions')
+})

--- a/portfolio-tracker/tests/setup-env.js
+++ b/portfolio-tracker/tests/setup-env.js
@@ -2,4 +2,4 @@ if (typeof window !== 'undefined') {
   window.location.assign('http://localhost');
 }
 
-process.env.VITE_API_URL = 'http://localhost/api';
+process.env.VITE_PORTFOLIO_API = 'http://localhost/api';


### PR DESCRIPTION
## Summary
- migrate Vite env examples to `VITE_PORTFOLIO_API`
- adjust test setup for new variable
- add regression test ensuring `<App />` uses the API base

## Testing
- `npm test --silent`
- `npm run build --silent`


------
https://chatgpt.com/codex/tasks/task_e_684c7aee6f448330bc34233f4a2378c7