### PR TITLE
Implement AlphaVantage quote caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ uvicorn src.main:app --reload
 Each build stamps the current commit hash into the app. The footer will display
 the version like `v4e96b97` corresponding to the commit used for the build.
 
-The API reads optional environment variables like `SECRET_KEY`, `DATABASE_URL` and `BASE_CURRENCY`. Default values are provided so it will start without extra configuration. Historical price lookups use the minimal `ApiClient` in `portfolio-api/src/data_api.py`.
+The API reads optional environment variables like `SECRET_KEY`, `DATABASE_URL` and `BASE_CURRENCY`. Default values are provided so it will start without extra configuration. Historical price lookups use the minimal `ApiClient` in `portfolio-api/src/data_api.py`. To enable live quote lookups via Alpha Vantage set `ALPHAVANTAGE_API_KEY`.
 
 # My Portfolio
 

--- a/portfolio-api/src/routes/portfolio.py
+++ b/portfolio-api/src/routes/portfolio.py
@@ -7,38 +7,10 @@ from datetime import datetime, date, timedelta
 import os
 
 from src.data_api import ApiClient
+from src.services.market_data import fetch_quote, QuoteAPIError
 
 portfolio_bp = Blueprint('portfolio', __name__)
 client = ApiClient()
-
-# --- price lookup helpers ----------------------------------------------------
-
-class QuoteAPIError(Exception):
-    """Raised when the external quote service fails"""
-
-
-def fetch_quote(symbol: str):
-    """Return the latest price for *symbol* or None if unavailable."""
-    # Avoid external calls when no API key is configured
-    if not getattr(client, "api_key", None):
-        return None
-    try:
-        data = client.call_api(
-            "YahooFinance/get_stock_chart",
-            query={"symbol": symbol, "interval": "1d", "range": "1d"},
-        )
-    except Exception as exc:  # network or API error
-        raise QuoteAPIError(str(exc)) from exc
-
-    if not data or "chart" not in data or "result" not in data["chart"]:
-        return None
-    results = data["chart"]["result"]
-    if not results:
-        return None
-    meta = results[0].get("meta", {})
-    if not meta:
-        return None
-    return meta.get("regularMarketPrice")
 
 # Return JSON for not found errors within this blueprint
 @portfolio_bp.errorhandler(404)

--- a/portfolio-api/src/services/market_data.py
+++ b/portfolio-api/src/services/market_data.py
@@ -1,0 +1,40 @@
+import os
+import time
+import requests
+
+class QuoteAPIError(Exception):
+    """Raised when the external quote service fails"""
+
+
+_CACHE = {}
+_CACHE_TTL = 60  # seconds
+_API_URL = "https://www.alphavantage.co/query"
+
+
+def fetch_quote(symbol: str):
+    """Return the latest price for *symbol* or None if unavailable."""
+    api_key = os.environ.get("ALPHAVANTAGE_API_KEY")
+    if not api_key:
+        return None
+
+    symbol = symbol.upper()
+    now = time.time()
+    cached = _CACHE.get(symbol)
+    if cached and now - cached[1] < _CACHE_TTL:
+        return cached[0]
+
+    params = {
+        "function": "GLOBAL_QUOTE",
+        "symbol": symbol,
+        "apikey": api_key,
+    }
+    try:
+        resp = requests.get(_API_URL, params=params, timeout=10)
+        resp.raise_for_status()
+        data = resp.json()
+        price = float(data["Global Quote"]["05. price"])
+    except Exception as exc:
+        raise QuoteAPIError(str(exc)) from exc
+
+    _CACHE[symbol] = (price, now)
+    return price

--- a/portfolio-api/tests/test_market_data.py
+++ b/portfolio-api/tests/test_market_data.py
@@ -1,0 +1,30 @@
+import json
+from src.services import market_data
+
+
+def test_search_aapl_success(monkeypatch, client):
+    market_data._CACHE.clear()
+    monkeypatch.setenv("ALPHAVANTAGE_API_KEY", "demo")
+
+    fake_json = {
+        "Global Quote": {
+            "01. symbol": "AAPL",
+            "05. price": "123.45",
+        }
+    }
+
+    def fake_get(url, params=None, **kwargs):
+        class R:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return fake_json
+        return R()
+
+    monkeypatch.setattr(market_data.requests, "get", fake_get)
+
+    resp = client.get("/api/portfolio/stocks/search/AAPL")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["symbol"] == "AAPL"
+    assert data["price"] == 123.45


### PR DESCRIPTION
## Summary
- introduce `market_data` service with Alpha Vantage integration
- update stock search blueprint to use the new service
- cache live quote results for 60 seconds
- document `ALPHAVANTAGE_API_KEY` env var
- test quote retrieval via `test_market_data.py`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d401bea808330bfb864a46a5d7356