### PR TITLE
Implement client-side portfolio metric calculation

### DIFF
--- a/portfolio-tracker/src/components/PortfolioOverview.jsx
+++ b/portfolio-tracker/src/components/PortfolioOverview.jsx
@@ -4,11 +4,15 @@ import { useState } from 'react'
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select.jsx'
 import PortfolioHistoryChart from './PortfolioHistoryChart'
 import { sortPerformanceData } from '@/lib/sort.js'
+import { calcPortfolioMetrics } from '@/lib/calcPortfolioMetrics'
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8', '#82CA9D', '#FFC658', '#FF7C7C']
 
-function PortfolioOverview({ portfolioData, portfolioSummary }) {
-  if (!portfolioData || portfolioData.length === 0) {
+function PortfolioOverview({ portfolioData }) {
+  const metrics = calcPortfolioMetrics(portfolioData || [])
+  const portfolioSummary = metrics
+  const data = metrics.holdings
+  if (!data || data.length === 0) {
     return (
       <Card>
         <CardHeader>
@@ -25,7 +29,7 @@ function PortfolioOverview({ portfolioData, portfolioSummary }) {
   }
 
   // Prepare data for pie chart (allocation by value)
-  const allocationData = portfolioData.map((stock, index) => ({
+  const allocationData = data.map((stock, index) => ({
     name: stock.symbol,
     value: stock.current_value,
     percentage: portfolioSummary ? ((stock.current_value / portfolioSummary.total_value) * 100).toFixed(1) : 0,
@@ -33,7 +37,7 @@ function PortfolioOverview({ portfolioData, portfolioSummary }) {
   }))
 
   // Prepare data for performance chart
-  const performanceData = portfolioData.map(stock => ({
+  const performanceData = data.map(stock => ({
     symbol: stock.symbol,
     gain: stock.total_gain,
     gainPercent: stock.total_gain_percent,
@@ -165,7 +169,8 @@ function PortfolioOverview({ portfolioData, portfolioSummary }) {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            {portfolioData
+            {data
+              .slice()
               .sort((a, b) => b.total_gain_percent - a.total_gain_percent)
               .slice(0, 5)
               .map((stock) => (
@@ -196,7 +201,7 @@ function PortfolioOverview({ portfolioData, portfolioSummary }) {
         </CardHeader>
         <CardContent>
           <div className="space-y-4">
-            {portfolioData.map((stock) => (
+            {data.map((stock) => (
               <div key={stock.symbol} className="flex items-center justify-between">
                 <div>
                   <p className="font-medium">{stock.symbol}</p>

--- a/portfolio-tracker/src/components/PortfolioSummary.jsx
+++ b/portfolio-tracker/src/components/PortfolioSummary.jsx
@@ -1,0 +1,72 @@
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
+import { Badge } from '@/components/ui/badge.jsx'
+import { TrendingUp, TrendingDown, DollarSign } from 'lucide-react'
+
+function PortfolioSummary({ summary }) {
+  if (!summary) return null
+  return (
+    <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Total Value</CardTitle>
+          <DollarSign className="h-4 w-4 text-muted-foreground" />
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">${summary.total_value.toLocaleString()}</div>
+          <p className="text-xs text-muted-foreground">
+            Cost basis: ${summary.total_cost_basis.toLocaleString()}
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Total Gain/Loss</CardTitle>
+          {summary.total_gain >= 0 ? (
+            <TrendingUp className="h-4 w-4 text-green-600" />
+          ) : (
+            <TrendingDown className="h-4 w-4 text-red-600" />
+          )}
+        </CardHeader>
+        <CardContent>
+          <div className={`text-2xl font-bold ${summary.total_gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            ${summary.total_gain.toLocaleString()}
+          </div>
+          <p className={`text-xs ${summary.total_gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            {summary.total_gain_percent >= 0 ? '+' : ''}{summary.total_gain_percent.toFixed(2)}%
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Holdings</CardTitle>
+          <Badge variant="secondary">{summary.stocks_count}</Badge>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">{summary.stocks_count}</div>
+          <p className="text-xs text-muted-foreground">Different stocks</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Performance</CardTitle>
+          {summary.total_gain_percent >= 0 ? (
+            <TrendingUp className="h-4 w-4 text-green-600" />
+          ) : (
+            <TrendingDown className="h-4 w-4 text-red-600" />
+          )}
+        </CardHeader>
+        <CardContent>
+          <div className={`text-2xl font-bold ${summary.total_gain_percent >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+            {summary.total_gain_percent >= 0 ? '+' : ''}{summary.total_gain_percent.toFixed(2)}%
+          </div>
+          <p className="text-xs text-muted-foreground">Overall return</p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}
+
+export default PortfolioSummary

--- a/portfolio-tracker/src/hooks/usePortfolio.ts
+++ b/portfolio-tracker/src/hooks/usePortfolio.ts
@@ -1,0 +1,61 @@
+import { useEffect, useState } from 'react'
+import { fetchStocks, fetchTransactions, post } from '@/lib/api'
+import {
+  calcPortfolioMetrics,
+  HoldingMetrics,
+  PortfolioMetrics,
+} from '@/lib/calcPortfolioMetrics'
+
+export function usePortfolio() {
+  const [holdings, setHoldings] = useState<HoldingMetrics[]>([])
+  const [metrics, setMetrics] = useState<PortfolioMetrics | null>(null)
+  const [transactions, setTransactions] = useState<any[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const loadData = async () => {
+    setLoading(true)
+    try {
+      const [stocksResp, txResp] = await Promise.all([
+        fetchStocks(),
+        fetchTransactions(),
+      ])
+      const [stocks, txs] = await Promise.all([
+        stocksResp.json(),
+        txResp.json(),
+      ])
+      const computed = calcPortfolioMetrics(stocks)
+      setHoldings(computed.holdings)
+      setMetrics(computed)
+      setTransactions(txs)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  useEffect(() => {
+    loadData()
+  }, [])
+
+  const refresh = loadData
+
+  const updatePrices = async () => {
+    setLoading(true)
+    try {
+      for (const h of holdings) {
+        await post(`/stocks/${h.symbol}/price`, {})
+      }
+      await loadData()
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return {
+    holdings,
+    metrics,
+    transactions,
+    loading,
+    refresh,
+    updatePrices,
+  }
+}

--- a/portfolio-tracker/src/lib/calcPortfolioMetrics.ts
+++ b/portfolio-tracker/src/lib/calcPortfolioMetrics.ts
@@ -1,0 +1,55 @@
+export interface Holding {
+  symbol: string
+  company_name?: string
+  quantity: number
+  avg_cost_basis: number
+  current_price?: number | null
+}
+
+export interface HoldingMetrics extends Holding {
+  current_value: number
+  cost_basis: number
+  total_gain: number
+  total_gain_percent: number
+}
+
+export interface PortfolioMetrics {
+  total_value: number
+  total_cost_basis: number
+  total_gain: number
+  total_gain_percent: number
+  stocks_count: number
+  holdings: HoldingMetrics[]
+}
+
+export function calcPortfolioMetrics(holdings: Holding[]): PortfolioMetrics {
+  let totalValue = 0
+  let totalCostBasis = 0
+  const metrics: HoldingMetrics[] = holdings.map((h) => {
+    const price = h.current_price ?? 0
+    const currentValue = h.quantity * price
+    const costBasis = h.quantity * h.avg_cost_basis
+    const totalGain = currentValue - costBasis
+    const totalGainPercent = costBasis > 0 ? (totalGain / costBasis) * 100 : 0
+    totalValue += currentValue
+    totalCostBasis += costBasis
+    return {
+      ...h,
+      current_value: currentValue,
+      cost_basis: costBasis,
+      total_gain: totalGain,
+      total_gain_percent: totalGainPercent,
+    }
+  })
+  const totalGain = totalValue - totalCostBasis
+  const totalGainPercent =
+    totalCostBasis > 0 ? (totalGain / totalCostBasis) * 100 : 0
+  return {
+    total_value: totalValue,
+    total_cost_basis: totalCostBasis,
+    total_gain: totalGain,
+    total_gain_percent: totalGainPercent,
+    stocks_count: metrics.length,
+    holdings: metrics,
+  }
+}

--- a/portfolio-tracker/tests/__snapshots__/calcPortfolioMetrics.test.ts.snap
+++ b/portfolio-tracker/tests/__snapshots__/calcPortfolioMetrics.test.ts.snap
@@ -1,0 +1,33 @@
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`calcPortfolioMetrics computes totals 1`] = `
+{
+  "holdings": [
+    {
+      "avg_cost_basis": 100,
+      "cost_basis": 1000,
+      "current_price": 150,
+      "current_value": 1500,
+      "quantity": 10,
+      "symbol": "AAPL",
+      "total_gain": 500,
+      "total_gain_percent": 50,
+    },
+    {
+      "avg_cost_basis": 200,
+      "cost_basis": 1000,
+      "current_price": 180,
+      "current_value": 900,
+      "quantity": 5,
+      "symbol": "MSFT",
+      "total_gain": -100,
+      "total_gain_percent": -10,
+    },
+  ],
+  "stocks_count": 2,
+  "total_cost_basis": 2000,
+  "total_gain": 400,
+  "total_gain_percent": 20,
+  "total_value": 2400,
+}
+`;

--- a/portfolio-tracker/tests/calcPortfolioMetrics.test.ts
+++ b/portfolio-tracker/tests/calcPortfolioMetrics.test.ts
@@ -1,0 +1,10 @@
+import { calcPortfolioMetrics } from '../src/lib/calcPortfolioMetrics'
+
+test('calcPortfolioMetrics computes totals', () => {
+  const holdings = [
+    { symbol: 'AAPL', quantity: 10, avg_cost_basis: 100, current_price: 150 },
+    { symbol: 'MSFT', quantity: 5, avg_cost_basis: 200, current_price: 180 },
+  ]
+  const result = calcPortfolioMetrics(holdings)
+  expect(result).toMatchSnapshot()
+})

--- a/portfolio-tracker/tests/health.spec.ts
+++ b/portfolio-tracker/tests/health.spec.ts
@@ -23,6 +23,5 @@ test('App fetches data from configured API base', async () => {
   await waitFor(() => expect(global.fetch).toHaveBeenCalled())
 
   expect(global.fetch).toHaveBeenCalledWith('http://test/stocks')
-  expect(global.fetch).toHaveBeenCalledWith('http://test/portfolio/summary')
   expect(global.fetch).toHaveBeenCalledWith('http://test/transactions')
 })

--- a/portfolio-tracker/tests/holdingsPrice.test.tsx
+++ b/portfolio-tracker/tests/holdingsPrice.test.tsx
@@ -32,5 +32,6 @@ test('shows fetched current price', async () => {
     />
   )
   await waitFor(() => expect(global.fetch).toHaveBeenCalled())
-  expect(await screen.findByText(/123\.45/)).toBeInTheDocument()
+  const matches = await screen.findAllByText(/123\.45/)
+  expect(matches.length).toBeGreaterThan(0)
 })


### PR DESCRIPTION
## Summary
- compute portfolio metrics on the client via `calcPortfolioMetrics`
- add `usePortfolio` hook to load holdings and transactions
- refactor overview and holdings components to use computed metrics
- extract `PortfolioSummary` component
- unit test `calcPortfolioMetrics`
- update existing tests

## Testing
- `npm test --silent`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684d544f14c083308775afd072d4f953