### PR TITLE
Add parser for Google Finance activity

### DIFF
--- a/portfolio-api/src/routes/import_routes.py
+++ b/portfolio-api/src/routes/import_routes.py
@@ -1,90 +1,17 @@
-import re
 from datetime import datetime
 from flask import Blueprint, request, jsonify
 from src.models.portfolio import Stock, Transaction, CurrencyEnum
 from src.models.user import db
+from src.services.google_finance import parse_raw
 
 import_bp = Blueprint('import', __name__)
-
-HEADER_RE = re.compile(r"^(?P<ticker>[A-Z]{2,5})\s+(?P<side>purchase|sale)$", re.I)
-DETAIL_RE = re.compile(
-    r"^(?P<date>\d{1,2}/\d{1,2}/\d{4})\s+(?P<shares>[\d.,]+)\s+shares?\s+(?:@|at)\s+[€$]?(?P<price>[\d.,]+)",
-    re.I,
-)
-
-
-def _parse_number(text: str) -> float | None:
-    clean = text.replace("\u202f", "").replace(" ", "")
-    clean = clean.replace("€", "").replace("$", "")
-    if clean.count(",") > 0 and clean.count(".") > 0:
-        if clean.rfind(",") > clean.rfind("."):
-            clean = clean.replace(".", "").replace(",", ".")
-        else:
-            clean = clean.replace(",", "")
-    elif clean.count(",") > 0:
-        clean = clean.replace(",", ".")
-    try:
-        return float(clean)
-    except ValueError:
-        return None
-
-
-def _parse_block(lines):
-    if len(lines) < 3:
-        return None
-    m1 = HEADER_RE.match(lines[0])
-    if not m1:
-        return None
-    m2 = DETAIL_RE.match(lines[2])
-    if not m2:
-        return None
-    amount = _parse_number(lines[1])
-    date_str = m2.group("date")
-    try:
-        date = datetime.strptime(date_str, "%d/%m/%Y").date()
-    except ValueError:
-        return None
-    shares = _parse_number(m2.group("shares"))
-    price = _parse_number(m2.group("price"))
-    currency = "USD"
-    if "€" in lines[1] or "€" in lines[2]:
-        currency = "EUR"
-    row = {
-        "ticker": m1.group("ticker").upper(),
-        "action": m1.group("side").lower(),
-        "date": date.isoformat(),
-        "shares": shares,
-        "price": price,
-        "amount": round((shares or 0) * (price or 0), 2),
-        "currency": currency,
-    }
-    if None in row.values():
-        return None
-    return row
-
-
-def _parse_raw(raw: str):
-    lines = [ln.strip() for ln in raw.splitlines() if ln.strip()]
-    rows = []
-    invalid = []
-    i = 0
-    while i < len(lines):
-        chunk = lines[i:i+3]
-        row = _parse_block(chunk)
-        if row:
-            rows.append(row)
-            i += 3
-        else:
-            invalid.append(lines[i])
-            i += 1
-    return rows, invalid
 
 
 @import_bp.route('/google-finance/preview', methods=['POST'])
 def google_finance_preview():
     data = request.get_json(force=True)
     raw = data.get('raw', '')
-    rows, invalid = _parse_raw(raw)
+    rows, invalid = parse_raw(raw)
     return jsonify({"rows": rows, "invalid_rows": invalid})
 
 
@@ -92,7 +19,7 @@ def google_finance_preview():
 def google_finance_import():
     data = request.get_json(force=True)
     raw = data.get('raw', '')
-    rows, invalid = _parse_raw(raw)
+    rows, invalid = parse_raw(raw)
     ids = []
     duplicates = 0
     for row in rows:
@@ -118,7 +45,7 @@ def google_finance_import():
             transaction_type=side,
             quantity=int(row['shares']),
             price_per_share=float(row['price']),
-            currency=CurrencyEnum[row['currency']],
+            currency=CurrencyEnum['USD' if row['currency'] == '$' else 'EUR'],
             fx_rate=1.0,
             transaction_date=date_obj,
         )

--- a/portfolio-api/src/services/google_finance.py
+++ b/portfolio-api/src/services/google_finance.py
@@ -1,0 +1,83 @@
+import re
+from datetime import datetime
+
+HEADER_RE = re.compile(r"^(?P<ticker>\S+)\s+(?P<action>purchase|sale)$", re.I)
+DETAIL_RE = re.compile(r"(?P<shares>\d+(?:[.,]\d+)?) shares (?:@|at) (?P<symbol>[€$]?)(?P<price>\d+(?:[.,]\d+)?)", re.I)
+DATE_RE = re.compile(r"(?P<date>\d{1,2}/\d{1,2}/\d{4})")
+
+
+def _parse_number(text: str) -> float | None:
+    clean = text.replace("\u202f", "").replace(" ", "")
+    clean = clean.replace("€", "").replace("$", "")
+    if clean.count(",") > 0 and clean.count(".") > 0:
+        if clean.rfind(",") > clean.rfind("."):
+            clean = clean.replace(".", "").replace(",", ".")
+        else:
+            clean = clean.replace(",", "")
+    elif clean.count(",") > 0:
+        clean = clean.replace(",", ".")
+    try:
+        return float(clean)
+    except ValueError:
+        return None
+
+
+def _parse_group(lines: list[str]):
+    if len(lines) < 3:
+        return None
+    m_header = HEADER_RE.match(lines[0])
+    if not m_header:
+        return None
+    detail = lines[2]
+    m_detail = DETAIL_RE.search(detail)
+    date_m = DATE_RE.search(detail)
+    if not (m_detail and date_m):
+        return None
+    shares = _parse_number(m_detail.group("shares"))
+    price = _parse_number(m_detail.group("price"))
+    symbol = m_detail.group("symbol") or lines[1].strip()[:1]
+    if symbol not in ("$", "€"):
+        symbol = "$"
+    try:
+        date = datetime.strptime(date_m.group("date"), "%d/%m/%Y").date()
+    except ValueError:
+        return None
+    row = {
+        "ticker": m_header.group("ticker").upper(),
+        "action": m_header.group("action").lower(),
+        "date": date.isoformat(),
+        "shares": shares,
+        "price": price,
+        "amount": round((shares or 0) * (price or 0), 2),
+        "currency": symbol,
+    }
+    if None in row.values():
+        return None
+    return row
+
+
+def parse_raw(raw: str):
+    lines = raw.splitlines()
+    groups: list[list[str]] = []
+    current: list[str] = []
+    for ln in lines:
+        stripped = ln.strip()
+        if not stripped or stripped == "universal_currency_alt":
+            if current:
+                groups.append(current)
+                current = []
+            continue
+        current.append(stripped)
+    if current:
+        groups.append(current)
+
+    rows = []
+    invalid = []
+    for g in groups:
+        row = _parse_group(g)
+        if row:
+            rows.append(row)
+        else:
+            if g:
+                invalid.append(g[0])
+    return rows, invalid

--- a/portfolio-api/tests/test_google_finance_parser.py
+++ b/portfolio-api/tests/test_google_finance_parser.py
@@ -1,0 +1,136 @@
+import textwrap
+from src.services.google_finance import parse_raw
+
+SAMPLE = textwrap.dedent("""
+SMCI sale
+€1,080.82
+27/05/2025 · 26 shares at €41.57
+Gain
+9.39%, +92.82
+Invested 85 days
+universal_currency_alt
+GOOG purchase
+€6,720.00
+14/05/2025 · 42 shares at €160.00
+MSFT sale
+€2,246.25
+13/05/2025 · 5 shares at €449.25
+Gain
+17.09%, +327.90
+Invested 53 days
+MSFT sale
+€2,245.70
+13/05/2025 · 5 shares at €449.14
+Gain
+10.04%, +204.95
+Invested 78 days
+MSFT sale
+€2,245.70
+13/05/2025 · 5 shares at €449.14
+Gain
+9.99%, +204.00
+Invested 90 days
+universal_currency_alt
+AMZN purchase
+€2,805.00
+25/04/2025 · 15 shares at €187.00
+TSLA sale
+€895.04
+07/04/2025 · 4 shares at €223.76
+Returns
+33.70%, -454.96
+Invested 42 days
+TSLA sale
+€1,342.56
+07/04/2025 · 6 shares at €223.76
+Returns
+37.15%, -793.44
+Invested 56 days
+universal_currency_alt
+GOOG purchase
+€5,917.08
+07/04/2025 · 39 shares at €151.72
+UBI sale
+€5,835.00
+31/03/2025 · 500 shares at €11.67
+Gain
+7.56%, +410.00
+Invested 46 days
+universal_currency_alt
+MSFT purchase
+€1,918.35
+21/03/2025 · 5 shares at €383.67
+universal_currency_alt
+GOOG purchase
+€1,612.80
+21/03/2025 · 10 shares at €161.28
+universal_currency_alt
+NVDA purchase
+€4,836.30
+12/03/2025 · 42 shares at €115.15
+universal_currency_alt
+SMCI purchase
+€988.00
+03/03/2025 · 26 shares at €38.00
+universal_currency_alt
+NVDA purchase
+€8,845.50
+28/02/2025 · 75 shares at €117.94
+universal_currency_alt
+TSLA purchase
+€1,350.00
+24/02/2025 · 4 shares at €337.50
+universal_currency_alt
+NVDA purchase
+€1,350.00
+24/02/2025 · 10 shares at €135.00
+universal_currency_alt
+MSFT purchase
+€2,040.75
+24/02/2025 · 5 shares at €408.15
+universal_currency_alt
+GOOG purchase
+€1,796.50
+24/02/2025 · 10 shares at €179.65
+universal_currency_alt
+UBI purchase
+€5,425.00
+13/02/2025 · 500 shares at €10.85
+universal_currency_alt
+UBER purchase
+€2,226.00
+12/02/2025 · 28 shares at €79.50
+universal_currency_alt
+NVDA purchase
+€13,115.00
+12/02/2025 · 100 shares at €131.15
+universal_currency_alt
+MSFT purchase
+€2,041.70
+12/02/2025 · 5 shares at €408.34
+universal_currency_alt
+AMZN purchase
+€2,301.40
+12/02/2025 · 10 shares at €230.14
+universal_currency_alt
+GOOG purchase
+€2,204.76
+12/02/2025 · 12 shares at €183.73
+universal_currency_alt
+TSLA purchase
+€2,136.00
+10/02/2025 · 6 shares at €356.00
+""")
+
+
+def test_parse_activity_sample():
+    rows, invalid = parse_raw(SAMPLE)
+    assert not invalid
+    assert len(rows) == 20
+    first = rows[0]
+    assert first["ticker"] == "SMCI"
+    assert first["action"] == "sale"
+    assert first["currency"] == "€"
+    assert first["shares"] == 26
+    assert first["price"] == 41.57
+    assert first["date"] == "2025-05-27"

--- a/portfolio-tracker/src/components/ImportDialog.tsx
+++ b/portfolio-tracker/src/components/ImportDialog.tsx
@@ -5,6 +5,7 @@ import { Textarea } from '@/components/ui/textarea.jsx'
 import { Table, TableHeader, TableHead, TableRow, TableBody, TableCell } from '@/components/ui/table.jsx'
 import { Alert, AlertDescription } from '@/components/ui/alert.jsx'
 import { parseGoogleFinance, importGoogleFinance } from '@/lib/api'
+import { getCurrencySymbol } from '@/lib/utils.js'
 import { toast } from 'sonner'
 
 interface ImportDialogProps {
@@ -103,8 +104,8 @@ export default function ImportDialog({ open, onOpenChange, onImported }: ImportD
                       <TableCell>{r.action}</TableCell>
                       <TableCell>{new Date(r.date).toLocaleDateString()}</TableCell>
                       <TableCell className="text-right">{r.shares}</TableCell>
-                      <TableCell className="text-right">{r.price}</TableCell>
-                      <TableCell className="text-right">{r.amount}</TableCell>
+                      <TableCell className="text-right">{getCurrencySymbol(r.currency)}{r.price}</TableCell>
+                      <TableCell className="text-right">{getCurrencySymbol(r.currency)}{r.amount}</TableCell>
                     </TableRow>
                   ))}
                 </TableBody>


### PR DESCRIPTION
## Summary
- parse Google Finance activity groups with new service
- handle `$` and `€` currency symbols
- show currency symbol in preview table
- add regression test for sample activity

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_684d89aaad5c8330823d26ae2fdbf42a