### PR TITLE
Add temporary invalid rows debug output

### DIFF
--- a/portfolio-api/src/services/google_finance.py
+++ b/portfolio-api/src/services/google_finance.py
@@ -81,3 +81,9 @@ def parse_raw(raw: str):
             if g:
                 invalid.append(g[0])
     return rows, invalid
+
+
+def parse_google_finance_import(raw: str):
+    rows, invalid_rows = parse_raw(raw)
+    print("INVALID:", invalid_rows, flush=True)
+    return rows, invalid_rows


### PR DESCRIPTION
## Summary
- implement `parse_google_finance_import` helper
- print invalid rows for debugging

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d906f078c83309455e69f05dcae20