### PR TITLE
Add fee columns to Transaction

### DIFF
--- a/portfolio-api/migrations/versions/0003_add_fee_fx_columns.py
+++ b/portfolio-api/migrations/versions/0003_add_fee_fx_columns.py
@@ -1,0 +1,25 @@
+"""add fee and fx related columns"""
+
+from alembic import op
+import sqlalchemy as sa
+
+revision = '0003'
+down_revision = '0002'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('transaction', sa.Column('fee_amount', sa.Numeric(14, 4), nullable=True))
+    op.add_column('transaction', sa.Column('fee_currency', sa.String(length=3), nullable=True))
+    op.add_column('transaction', sa.Column('fx_rate', sa.Numeric(14, 6), nullable=True))
+    op.add_column('transaction', sa.Column('deal_amount', sa.Numeric(14, 2), nullable=True))
+    op.add_column('transaction', sa.Column('deal_currency', sa.String(length=3), nullable=True))
+
+
+def downgrade():
+    op.drop_column('transaction', 'deal_currency')
+    op.drop_column('transaction', 'deal_amount')
+    op.drop_column('transaction', 'fx_rate')
+    op.drop_column('transaction', 'fee_currency')
+    op.drop_column('transaction', 'fee_amount')

--- a/portfolio-api/src/models/portfolio.py
+++ b/portfolio-api/src/models/portfolio.py
@@ -43,7 +43,11 @@ class Transaction(db.Model):
     quantity = db.Column(db.Integer, nullable=False)
     price_per_share = db.Column(db.Float, nullable=False)
     currency = db.Column(db.Enum(CurrencyEnum), nullable=False, default=BASE_CURRENCY)
-    fx_rate = db.Column(db.Float, nullable=False, default=1.0)  # rate to convert to base currency
+    fee_amount = db.Column(db.Numeric(14, 4), nullable=True)
+    fee_currency = db.Column(db.String(3), nullable=True)
+    fx_rate = db.Column(db.Numeric(14, 6), nullable=True, default=1.0)
+    deal_amount = db.Column(db.Numeric(14, 2), nullable=True)
+    deal_currency = db.Column(db.String(3), nullable=True)
     transaction_date = db.Column(db.Date, nullable=False)
     created_at = db.Column(db.DateTime, default=datetime.utcnow)
     
@@ -59,7 +63,11 @@ class Transaction(db.Model):
             'quantity': self.quantity,
             'price_per_share': self.price_per_share,
             'currency': self.currency.value,
-            'fx_rate': self.fx_rate,
+            'fee_amount': float(self.fee_amount) if self.fee_amount is not None else None,
+            'fee_currency': self.fee_currency,
+            'fx_rate': float(self.fx_rate) if self.fx_rate is not None else None,
+            'deal_amount': float(self.deal_amount) if self.deal_amount is not None else None,
+            'deal_currency': self.deal_currency,
             'total_value': self.quantity * self.price_per_share,
             'total_value_base': self.total_value_base,
             'transaction_date': self.transaction_date.isoformat() if self.transaction_date else None,
@@ -72,7 +80,8 @@ class Transaction(db.Model):
 
     @property
     def total_value_base(self):
-        return self.quantity * self.price_per_share * self.fx_rate
+        rate = float(self.fx_rate) if self.fx_rate is not None else 1.0
+        return self.quantity * self.price_per_share * rate
 
 
 class PriceCache(db.Model):

--- a/portfolio-api/src/routes/import_routes.py
+++ b/portfolio-api/src/routes/import_routes.py
@@ -50,6 +50,10 @@ def google_finance_import():
             price_per_share=float(row['price']),
             currency=CurrencyEnum[currency_key],
             fx_rate=1.0,
+            fee_amount=row.get('fee_amount'),
+            fee_currency=row.get('fee_currency'),
+            deal_amount=row.get('deal_amount'),
+            deal_currency=row.get('deal_currency'),
             transaction_date=date_obj,
         )
         db.session.add(tx)

--- a/portfolio-api/src/routes/portfolio.py
+++ b/portfolio-api/src/routes/portfolio.py
@@ -243,6 +243,11 @@ def add_transaction():
             except Exception:
                 return jsonify({'error': 'Failed to fetch FX rate'}), 500
 
+        fee_amount = data.get('fee_amount')
+        fee_currency = data.get('fee_currency')
+        deal_amount = data.get('deal_amount')
+        deal_currency = data.get('deal_currency')
+
         transaction = Transaction(
             stock_id=stock.id,
             transaction_type=data['transaction_type'].lower(),
@@ -250,6 +255,10 @@ def add_transaction():
             price_per_share=float(data['price_per_share']),
             currency=CurrencyEnum[currency],
             fx_rate=fx_rate,
+            fee_amount=fee_amount,
+            fee_currency=fee_currency,
+            deal_amount=deal_amount,
+            deal_currency=deal_currency,
             transaction_date=transaction_date
         )
         


### PR DESCRIPTION
## Summary
- add migration for new Transaction fields
- store optional fee & deal data on transactions
- expose new fields via API
- handle Decimal FX conversions

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e70527660833091bc1ba53f2bcd2f