### PR TITLE
Show fees & net results in UI

### DIFF
--- a/portfolio-api/src/routes/portfolio.py
+++ b/portfolio-api/src/routes/portfolio.py
@@ -88,6 +88,11 @@ def get_all_stocks():
                 total_cost_orig = sum(
                     trade_cost(t) for t in buy_transactions if t.currency.value == tx_currency
                 )
+
+                fees_total = sum(
+                    tx_fee_to_ccy(t, base_currency)
+                    for t in buy_transactions + sell_transactions
+                )
                 
                 # Calculate current value and gains
                 current_value = current_quantity * (stock.current_price or 0)
@@ -105,7 +110,8 @@ def get_all_stocks():
                     'current_value': round(current_value * rate, 2),
                     'cost_basis': round(cost_basis * rate, 2),
                     'total_gain': round(total_gain * rate, 2),
-                    'total_gain_percent': round(total_gain_percent, 2)
+                    'total_gain_percent': round(total_gain_percent, 2),
+                    'fees_paid': round(fees_total * rate, 2)
                 })
                 portfolio_data.append(stock_data)
         

--- a/portfolio-api/tests/test_portfolio_endpoints.py
+++ b/portfolio-api/tests/test_portfolio_endpoints.py
@@ -317,3 +317,35 @@ def test_sell_fee_impacts_pl(client, monkeypatch):
     assert round(data['total_fees_paid'], 2) == 6.0
     assert round(data['net_gain_after_fees'], 2) == 194.0
 
+
+def test_fees_field_in_stock_list(client, monkeypatch):
+    monkeypatch.setattr('src.routes.portfolio.get_fx_rate', lambda *a, **k: 1.0)
+
+    buy = {
+        'symbol': 'AAPL',
+        'transaction_type': 'buy',
+        'quantity': 10,
+        'price_per_share': 10.0,
+        'transaction_date': '2024-01-01',
+        'currency': 'USD',
+        'fee_amount': 2.0,
+        'fee_currency': 'USD',
+    }
+    sell = {
+        'symbol': 'AAPL',
+        'transaction_type': 'sell',
+        'quantity': 5,
+        'price_per_share': 12.0,
+        'transaction_date': '2024-01-02',
+        'currency': 'USD',
+        'fee_amount': 1.0,
+        'fee_currency': 'USD',
+    }
+    client.post('/api/portfolio/transactions', json=buy)
+    client.post('/api/portfolio/transactions', json=sell)
+
+    resp = client.get('/api/portfolio/stocks')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert round(data[0]['fees_paid'], 2) == 3.0
+

--- a/portfolio-tracker/src/components/PortfolioOverview.jsx
+++ b/portfolio-tracker/src/components/PortfolioOverview.jsx
@@ -5,10 +5,12 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import PortfolioHistoryChart from './PortfolioHistoryChart'
 import { sortPerformanceData } from '@/lib/sort.js'
 import { calcPortfolioMetrics } from '@/lib/calcPortfolioMetrics'
+import { useSettings } from '@/store/settingsSlice'
 
 const COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#8884D8', '#82CA9D', '#FFC658', '#FF7C7C']
 
 function PortfolioOverview({ portfolioData }) {
+  const { includeFees } = useSettings()
   const metrics = calcPortfolioMetrics(portfolioData || [])
   const portfolioSummary = metrics
   const data = metrics.holdings
@@ -39,7 +41,7 @@ function PortfolioOverview({ portfolioData }) {
   // Prepare data for performance chart
   const performanceData = data.map(stock => ({
     symbol: stock.symbol,
-    gain: stock.total_gain,
+    gain: includeFees ? stock.total_gain - (stock.fees_paid ?? 0) : stock.total_gain,
     gainPercent: stock.total_gain_percent,
     currentValue: stock.current_value
   }))

--- a/portfolio-tracker/src/components/PortfolioSummary.jsx
+++ b/portfolio-tracker/src/components/PortfolioSummary.jsx
@@ -1,11 +1,14 @@
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Badge } from '@/components/ui/badge.jsx'
 import { TrendingUp, TrendingDown, DollarSign } from 'lucide-react'
+import { Switch } from '@/components/ui/switch.jsx'
+import { useSettings } from '@/store/settingsSlice'
 
 function PortfolioSummary({ summary }) {
+  const { includeFees, setIncludeFees } = useSettings()
   if (!summary) return null
   return (
-    <div className="grid grid-cols-1 md:grid-cols-5 gap-6 mb-8">
+    <div className="grid grid-cols-1 md:grid-cols-6 gap-6 mb-8">
       <Card>
         <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
           <CardTitle className="text-sm font-medium">Total Value</CardTitle>
@@ -78,6 +81,28 @@ function PortfolioSummary({ summary }) {
         <CardContent>
           <div className={`text-2xl font-bold ${summary.net_gain_after_fees >= 0 ? 'text-green-600' : 'text-red-600'}`}>${summary.net_gain_after_fees.toLocaleString()}</div>
           <p className="text-xs text-muted-foreground">Fees Paid: ${summary.total_fees_paid.toLocaleString()}</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Total Fees Paid</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="text-2xl font-bold">${summary.total_fees_paid.toLocaleString()}</div>
+          <p className="text-xs text-muted-foreground">Brokerage and trading fees</p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
+          <CardTitle className="text-sm font-medium">Include fees in performance</CardTitle>
+          <Switch checked={includeFees} onCheckedChange={setIncludeFees} id="fees-toggle" />
+        </CardHeader>
+        <CardContent>
+          <p className="text-xs text-muted-foreground">
+            Toggle to subtract fees when calculating gains
+          </p>
         </CardContent>
       </Card>
     </div>

--- a/portfolio-tracker/src/components/StockHoldings.jsx
+++ b/portfolio-tracker/src/components/StockHoldings.jsx
@@ -10,7 +10,7 @@ import { calcPortfolioMetrics } from '@/lib/calcPortfolioMetrics'
 import { useSettings } from '@/store/settingsSlice'
 
 function StockHoldings({ portfolioData, onRefresh, loading }) {
-  const { baseCurrency: BASE_CURRENCY } = useSettings()
+  const { baseCurrency: BASE_CURRENCY, includeFees } = useSettings()
   const [updatingStock, setUpdatingStock] = useState(null)
   const [prices, setPrices] = useState({})
 
@@ -100,6 +100,7 @@ function StockHoldings({ portfolioData, onRefresh, loading }) {
                 <TableHead className="text-right">Avg Cost</TableHead>
                 <TableHead className="text-right">Current Price</TableHead>
                 <TableHead className="text-right">Current Value</TableHead>
+                <TableHead className="text-right">Fees</TableHead>
                 <TableHead className="text-right">Total Gain/Loss</TableHead>
                 <TableHead className="text-right">Return %</TableHead>
                 <TableHead className="text-center">Actions</TableHead>
@@ -157,15 +158,19 @@ function StockHoldings({ portfolioData, onRefresh, loading }) {
                     {stock.current_value?.toLocaleString() || 'N/A'}
                   </TableCell>
                   <TableCell className="text-right">
+                    {getCurrencySymbol(BASE_CURRENCY)}
+                    {stock.fees_paid?.toLocaleString() || '0'}
+                  </TableCell>
+                  <TableCell className="text-right">
                     <div className="flex items-center justify-end gap-1">
-                      {stock.total_gain >= 0 ? (
+                      {(includeFees ? stock.total_gain - (stock.fees_paid ?? 0) : stock.total_gain) >= 0 ? (
                         <TrendingUp className="h-4 w-4 text-green-600" />
                       ) : (
                         <TrendingDown className="h-4 w-4 text-red-600" />
                       )}
-                      <span className={`font-medium ${stock.total_gain >= 0 ? 'text-green-600' : 'text-red-600'}`}> 
+                      <span className={`font-medium ${(includeFees ? stock.total_gain - (stock.fees_paid ?? 0) : stock.total_gain) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
                         {getCurrencySymbol(BASE_CURRENCY)}
-                        {stock.total_gain?.toLocaleString() || 'N/A'}
+                        {(includeFees ? stock.total_gain - (stock.fees_paid ?? 0) : stock.total_gain)?.toLocaleString() || 'N/A'}
                       </span>
                     </div>
                   </TableCell>
@@ -203,7 +208,7 @@ function StockHoldings({ portfolioData, onRefresh, loading }) {
 
         {/* Summary Row */}
         <div className="mt-6 pt-4 border-t">
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+          <div className="grid grid-cols-2 md:grid-cols-5 gap-4 text-sm">
             <div>
               <p className="text-gray-600">Total Positions</p>
               <p className="font-medium">{metrics.stocks_count}</p>
@@ -214,20 +219,27 @@ function StockHoldings({ portfolioData, onRefresh, loading }) {
                 {metrics.holdings.reduce((sum, s) => sum + s.quantity, 0).toLocaleString()}
               </p>
             </div>
-            <div>
-              <p className="text-gray-600">Total Value</p>
-              <p className="font-medium">
-                {getCurrencySymbol(BASE_CURRENCY)}
-                {metrics.total_value.toLocaleString()}
-              </p>
-            </div>
-            <div>
-              <p className="text-gray-600">Total Gain/Loss</p>
-              <p className={`font-medium ${metrics.total_gain >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                {getCurrencySymbol(BASE_CURRENCY)}
-                {metrics.total_gain.toLocaleString()}
-              </p>
-            </div>
+          <div>
+            <p className="text-gray-600">Total Value</p>
+            <p className="font-medium">
+              {getCurrencySymbol(BASE_CURRENCY)}
+              {metrics.total_value.toLocaleString()}
+            </p>
+          </div>
+          <div>
+            <p className="text-gray-600">Total Fees</p>
+            <p className="font-medium">
+              {getCurrencySymbol(BASE_CURRENCY)}
+              {metrics.total_fees_paid.toLocaleString()}
+            </p>
+          </div>
+          <div>
+            <p className="text-gray-600">Total Gain/Loss</p>
+            <p className={`font-medium ${(includeFees ? metrics.net_gain_after_fees : metrics.total_gain) >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+              {getCurrencySymbol(BASE_CURRENCY)}
+              {(includeFees ? metrics.net_gain_after_fees : metrics.total_gain).toLocaleString()}
+            </p>
+          </div>
           </div>
         </div>
       </CardContent>

--- a/portfolio-tracker/src/lib/calcPortfolioMetrics.ts
+++ b/portfolio-tracker/src/lib/calcPortfolioMetrics.ts
@@ -4,6 +4,7 @@ export interface Holding {
   quantity: number
   avg_cost_basis: number
   current_price?: number | null
+  fees_paid?: number
 }
 
 export interface HoldingMetrics extends Holding {
@@ -27,6 +28,7 @@ export interface PortfolioMetrics {
 export function calcPortfolioMetrics(holdings: Holding[]): PortfolioMetrics {
   let totalValue = 0
   let totalCostBasis = 0
+  let totalFees = 0
   const metrics: HoldingMetrics[] = holdings.map((h) => {
     const price = h.current_price ?? 0
     const currentValue = h.quantity * price
@@ -35,6 +37,7 @@ export function calcPortfolioMetrics(holdings: Holding[]): PortfolioMetrics {
     const totalGainPercent = costBasis > 0 ? (totalGain / costBasis) * 100 : 0
     totalValue += currentValue
     totalCostBasis += costBasis
+    totalFees += h.fees_paid ?? 0
     return {
       ...h,
       current_value: currentValue,
@@ -51,8 +54,8 @@ export function calcPortfolioMetrics(holdings: Holding[]): PortfolioMetrics {
     total_cost_basis: totalCostBasis,
     total_gain: totalGain,
     total_gain_percent: totalGainPercent,
-    total_fees_paid: 0,
-    net_gain_after_fees: totalGain,
+    total_fees_paid: totalFees,
+    net_gain_after_fees: totalGain - totalFees,
     stocks_count: metrics.length,
     holdings: metrics,
   }

--- a/portfolio-tracker/src/store/settingsSlice.tsx
+++ b/portfolio-tracker/src/store/settingsSlice.tsx
@@ -4,25 +4,38 @@ const DEFAULT_BASE = (import.meta?.env?.VITE_BASE_CURRENCY as string) || 'USD'
 
 type SettingsState = {
   baseCurrency: string
+  includeFees: boolean
   setBaseCurrency: (c: string) => void
+  setIncludeFees: (v: boolean) => void
 }
 
 const SettingsContext = createContext<SettingsState>({
   baseCurrency: DEFAULT_BASE,
+  includeFees: false,
   setBaseCurrency: () => {},
+  setIncludeFees: () => {},
 })
 
 export function SettingsProvider({ children }: { children: React.ReactNode }) {
   const [baseCurrency, setBaseCurrency] = useState(
     () => localStorage.getItem('baseCurrency') || DEFAULT_BASE
   )
+  const [includeFees, setIncludeFees] = useState(
+    () => localStorage.getItem('includeFees') === 'true'
+  )
 
   useEffect(() => {
     localStorage.setItem('baseCurrency', baseCurrency)
   }, [baseCurrency])
 
+  useEffect(() => {
+    localStorage.setItem('includeFees', includeFees ? 'true' : 'false')
+  }, [includeFees])
+
   return (
-    <SettingsContext.Provider value={{ baseCurrency, setBaseCurrency }}>
+    <SettingsContext.Provider
+      value={{ baseCurrency, includeFees, setBaseCurrency, setIncludeFees }}
+    >
       {children}
     </SettingsContext.Provider>
   )

--- a/portfolio-tracker/tests/holdingsFees.test.tsx
+++ b/portfolio-tracker/tests/holdingsFees.test.tsx
@@ -1,0 +1,32 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { jest } from '@jest/globals'
+import StockHoldings from '../src/components/StockHoldings'
+
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })) as any
+})
+
+afterEach(() => {
+  ;(global.fetch as any).mockReset()
+})
+
+const data = [
+  {
+    symbol: 'AAPL',
+    company_name: 'Apple',
+    quantity: 1,
+    avg_cost_basis: 100,
+    current_price: 150,
+    current_value: 150,
+    total_gain: 50,
+    total_gain_percent: 50,
+    fees_paid: 3.5,
+  },
+]
+
+test('shows fees column with numeric values', () => {
+  render(<StockHoldings portfolioData={data} onRefresh={() => {}} loading={false} />)
+  expect(screen.getByText('Fees')).toBeInTheDocument()
+  expect(screen.getAllByText(/3\.5/).length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary
- add per-stock fees from the backend
- store a UI setting to include/exclude fees
- show fees column in holdings and portfolio summary
- toggle performance to include fees
- adjust charts to respect setting
- test fees display

## Testing
- `pytest -q`
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_684e7a9c0b008330b23b4ce4ab2a2efb