### PR TITLE
Improve Google finance importer

### DIFF
--- a/portfolio-api/tests/fixtures/2025-05-21-1472929072.txt
+++ b/portfolio-api/tests/fixtures/2025-05-21-1472929072.txt
@@ -1,0 +1,5 @@
+MSFT sale
+€900,00
+21/05/2025 3 shares @ €300,00
+Kurtage -2,00 EUR
+VALUTAKURS 11,20

--- a/portfolio-api/tests/fixtures/avrakningsnota_nr_250527106476.txt
+++ b/portfolio-api/tests/fixtures/avrakningsnota_nr_250527106476.txt
@@ -1,0 +1,5 @@
+GOOGL purchase
+$1,500.00
+27/05/2025 5 shares @ $300.00
+Courtage -1.50 USD
+Växlingskurs 11.50

--- a/portfolio-api/tests/test_google_finance_parser.py
+++ b/portfolio-api/tests/test_google_finance_parser.py
@@ -1,4 +1,5 @@
 import textwrap
+from pathlib import Path
 from src.services.google_finance import parse_raw
 
 SAMPLE = textwrap.dedent("""
@@ -159,3 +160,31 @@ def test_parse_pln_activity():
     assert row["currency"] == "PLN"
     assert row["shares"] == 10
     assert row["price"] == 100.0
+
+
+def read_fixture(name: str) -> str:
+    path = Path(__file__).parent / "fixtures" / name
+    with open(path, "r", encoding="utf-8") as fh:
+        return fh.read()
+
+
+def test_parse_avanza_fee_fx():
+    raw = read_fixture("avrakningsnota_nr_250527106476.txt")
+    rows, invalid = parse_raw(raw)
+    assert not invalid
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["fee_amount"] == 1.5
+    assert row["fee_currency"] == "USD"
+    assert row["fx_rate"] == 11.5
+
+
+def test_parse_seb_fee_fx():
+    raw = read_fixture("2025-05-21-1472929072.txt")
+    rows, invalid = parse_raw(raw)
+    assert not invalid
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["fee_amount"] == 2.0
+    assert row["fee_currency"] == "EUR"
+    assert row["fx_rate"] == 11.2

--- a/portfolio-api/tests/test_import_google.py
+++ b/portfolio-api/tests/test_import_google.py
@@ -1,5 +1,6 @@
 import json
 from datetime import date
+from pathlib import Path
 
 def sample_raw():
     return """AAPL purchase
@@ -50,3 +51,19 @@ def test_invalid_lines_returned(client):
     data = resp.get_json()
     assert data['rows'] == []
     assert len(data['invalid_rows']) >= 1
+
+
+def read_fixture(name: str) -> str:
+    path = Path(__file__).parent / 'fixtures' / name
+    with open(path, 'r', encoding='utf-8') as fh:
+        return fh.read()
+
+
+def test_preview_parses_fee_and_fx(client):
+    raw = read_fixture('avrakningsnota_nr_250527106476.txt')
+    resp = client.post('/api/import/google-finance/preview', json={'raw': raw})
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert len(data['invalid_rows']) == 0
+    assert data['rows'][0]['fee_amount'] == 1.5
+    assert data['rows'][0]['fx_rate'] == 11.5


### PR DESCRIPTION
## Summary
- parse fee currency and fx lines in Google Finance importer
- add Avanza/SEB text fixture examples
- test fee and fx handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e7e6b8a1c8330bc085415db0023f6