### PR TITLE
Add fee tests with coverage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Portfolio Tracker
 
+[![codecov](https://codecov.io/gh/myorg/my-portfolio/branch/main/graph/badge.svg)](https://codecov.io/gh/myorg/my-portfolio)
+
 This repository contains a Flask backend (`portfolio-api`) and a React frontend (`portfolio-tracker`).
 
 ## Environment Variables

--- a/portfolio-api/tests/test_fee_summary.py
+++ b/portfolio-api/tests/test_fee_summary.py
@@ -1,0 +1,34 @@
+import json
+
+
+def test_fee_summary_after_migration(client, monkeypatch):
+    monkeypatch.setattr('src.routes.portfolio.get_fx_rate', lambda *a, **k: 1.0)
+    buy = {
+        'symbol': 'AAPL',
+        'transaction_type': 'buy',
+        'quantity': 100,
+        'price_per_share': 10.0,
+        'transaction_date': '2024-01-01',
+        'currency': 'EUR',
+        'fee_amount': 5.0,
+        'fee_currency': 'EUR',
+    }
+    sell = {
+        'symbol': 'AAPL',
+        'transaction_type': 'sell',
+        'quantity': 100,
+        'price_per_share': 12.0,
+        'transaction_date': '2024-01-02',
+        'currency': 'EUR',
+        'fee_amount': 1.0,
+        'fee_currency': 'EUR',
+    }
+
+    client.post('/api/portfolio/transactions', json=buy)
+    client.post('/api/portfolio/transactions', json=sell)
+
+    resp = client.get('/api/portfolio/summary')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert round(data['total_fees_paid'], 2) == 6.0
+    assert round(data['net_gain_after_fees'], 2) == 194.0

--- a/portfolio-tracker/tests/feesToggle.test.tsx
+++ b/portfolio-tracker/tests/feesToggle.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import StockHoldings from '../src/components/StockHoldings'
+import PortfolioSummary from '../src/components/PortfolioSummary'
+import { SettingsProvider } from '../src/store/settingsSlice'
+import { jest } from '@jest/globals'
+
+beforeEach(() => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve({}) })) as any
+  localStorage.clear()
+})
+
+afterEach(() => {
+  ;(global.fetch as any).mockReset()
+})
+
+const holdings = [
+  {
+    symbol: 'AAPL',
+    company_name: 'Apple',
+    quantity: 1,
+    avg_cost_basis: 100,
+    current_price: 150,
+    current_value: 150,
+    total_gain: 50,
+    total_gain_percent: 50,
+    fees_paid: 2,
+  },
+]
+
+const summary = {
+  total_value: 150,
+  total_cost_basis: 100,
+  total_gain: 50,
+  total_gain_percent: 50,
+  total_fees_paid: 2,
+  net_gain_after_fees: 48,
+  stocks_count: 1,
+}
+
+test('gain switches when fees toggle flipped', async () => {
+  const user = userEvent.setup()
+  render(
+    <SettingsProvider>
+      <PortfolioSummary summary={summary} />
+      <StockHoldings portfolioData={holdings} onRefresh={() => {}} loading={false} />
+    </SettingsProvider>
+  )
+  expect(screen.getAllByText('$50').length).toBeGreaterThan(0)
+  const toggle = screen.getByRole('switch')
+  await user.click(toggle)
+  expect(screen.getAllByText('$48').length).toBeGreaterThan(0)
+})

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --cov=src.models.portfolio --cov-report=term-missing --cov-fail-under=90

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,3 @@
 -r requirements.txt
 pytest>=7.4
+pytest-cov>=4.1


### PR DESCRIPTION
## Summary
- add Codecov badge to README
- require 90% test coverage for portfolio model
- test buy/sell workflow with fee summary
- test front-end fees toggle behavior

## Testing
- `npm test --prefix portfolio-tracker`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684e807e5cd8833093cd9f3d309a4376