### PR TITLE
Support Avanza Excel import

### DIFF
--- a/portfolio-api/requirements.txt
+++ b/portfolio-api/requirements.txt
@@ -12,3 +12,5 @@ Werkzeug==3.1.3
 requests==2.31.0
 uvicorn==0.29.0
 alembic==1.13.1
+pandas==2.3.0
+openpyxl==3.1.5

--- a/portfolio-api/src/routes/import_routes.py
+++ b/portfolio-api/src/routes/import_routes.py
@@ -3,6 +3,7 @@ from flask import Blueprint, request, jsonify
 from src.models.portfolio import Stock, Transaction, CurrencyEnum
 from src.models.user import db
 from src.services.google_finance import parse_raw
+from src.services.xlsx_import import parse_xlsx
 
 import_bp = Blueprint('import', __name__)
 
@@ -61,3 +62,12 @@ def google_finance_import():
         ids.append(tx.id)
     db.session.commit()
     return jsonify({"inserted_ids": ids, "invalid_rows": invalid, "duplicates_skipped": duplicates})
+
+
+@import_bp.route('/xlsx/preview', methods=['POST'])
+def xlsx_preview():
+    file = request.files.get('file')
+    if not file:
+        return jsonify({'error': 'No file uploaded'}), 400
+    rows, invalid = parse_xlsx(file)
+    return jsonify({"rows": rows, "invalid_rows": invalid})

--- a/portfolio-api/src/services/xlsx_import.py
+++ b/portfolio-api/src/services/xlsx_import.py
@@ -1,0 +1,55 @@
+import pandas as pd
+from .google_finance import _parse_number
+from datetime import datetime
+
+REQUIRED_COLS = ["Datum", "Typ", "Namn", "Antal/Belopp", "Kurs", "Belopp", "Valuta"]
+
+
+def parse_xlsx(file_obj):
+    df = pd.read_excel(file_obj, engine=None)
+    cols = list(df.columns)
+    if not all(c in cols for c in REQUIRED_COLS):
+        raise ValueError("Missing required columns")
+
+    rows = []
+    invalid = []
+    for _, row in df.iterrows():
+        try:
+            date_raw = row["Datum"]
+            if pd.isna(date_raw):
+                raise ValueError("missing date")
+            if isinstance(date_raw, str):
+                date = pd.to_datetime(date_raw).date()
+            else:
+                date = pd.to_datetime(str(date_raw)).date()
+
+            typ = str(row["Typ"]).lower()
+            if typ.startswith("k"):  # köp
+                action = "purchase"
+            elif typ.startswith("s"):  # sälj
+                action = "sale"
+            else:
+                continue  # skip non trade rows
+
+            ticker = str(row["Namn"]).strip()
+            qty = row["Antal/Belopp"]
+            price = row["Kurs"]
+            amount = row["Belopp"]
+            shares = _parse_number(str(qty)) if not isinstance(qty, (int, float)) else float(qty)
+            price = _parse_number(str(price)) if not isinstance(price, (int, float)) else float(price)
+            amount = _parse_number(str(amount)) if not isinstance(amount, (int, float)) else float(amount)
+            currency = str(row.get("Valuta", "SEK")).strip().upper()
+            if None in (shares, price, amount):
+                raise ValueError("missing numeric")
+            rows.append({
+                "ticker": ticker,
+                "action": action,
+                "date": date.isoformat(),
+                "shares": int(shares),
+                "price": float(price),
+                "amount": float(amount),
+                "currency": currency,
+            })
+        except Exception:
+            invalid.append(str(row.to_dict()))
+    return rows, invalid

--- a/portfolio-api/tests/test_import_xlsx.py
+++ b/portfolio-api/tests/test_import_xlsx.py
@@ -1,0 +1,24 @@
+from io import BytesIO
+
+import pandas as pd
+
+
+def test_xlsx_preview_returns_rows(client):
+    df = pd.DataFrame({
+        'Datum': pd.date_range('2024-01-01', periods=30),
+        'Typ': ['Köp'] * 30,
+        'Namn': ['AAPL'] * 30,
+        'Antal/Belopp': [10] * 30,
+        'Kurs': [100] * 30,
+        'Belopp': [1000] * 30,
+        'Valuta': ['SEK'] * 30,
+    })
+    bio = BytesIO()
+    df.to_excel(bio, index=False)
+    bio.seek(0)
+    data = {'file': (bio, 'avanza.xlsx')}
+    resp = client.post('/api/import/xlsx/preview', data=data, content_type='multipart/form-data')
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert len(body['rows']) >= 25
+    assert body['invalid_rows'] == []

--- a/portfolio-tracker/src/lib/api.ts
+++ b/portfolio-tracker/src/lib/api.ts
@@ -50,3 +50,14 @@ export async function importGoogleFinance(raw: string) {
   if (!resp.ok) throw new Error('Failed to import')
   return resp.json()
 }
+
+export async function parseXlsx(file: File) {
+  const form = new FormData()
+  form.append('file', file)
+  const resp = await fetch(`${IMPORT_API}/xlsx/preview`, {
+    method: 'POST',
+    body: form,
+  })
+  if (!resp.ok) throw new Error('Failed to parse')
+  return resp.json()
+}

--- a/portfolio-tracker/tests/importDialog.test.tsx
+++ b/portfolio-tracker/tests/importDialog.test.tsx
@@ -40,3 +40,13 @@ test('preview badge shows parsed and invalid counts', async () => {
   )
   expect(badge.textContent).toBe('Parsed 3 rows • 2 invalid')
 })
+
+test('xlsx file upload triggers preview', async () => {
+  const user = userEvent.setup()
+  render(<ImportDialog open={true} onOpenChange={() => {}} onImported={() => {}} />)
+  const input = screen.getByTestId('file-input') as HTMLInputElement
+  const file = new File(['dummy'], 'sample.xlsx', { type: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet' })
+  await user.upload(input, file)
+  await screen.findByText((_, el) => el?.textContent === 'Parsed 3 rows • 2 invalid')
+  expect(global.fetch).toHaveBeenCalledWith(expect.stringContaining('/xlsx/preview'), expect.any(Object))
+})


### PR DESCRIPTION
## Summary
- add optional pandas dependencies for Excel parsing
- preview Excel files via `/api/import/xlsx/preview`
- parse rows from Avanza Excel exports
- support drag & drop `.xlsx` files in Import dialog
- unit tests for the new parser and front-end behaviour
- remove binary xlsx fixtures and generate sample Excel files in tests

## Testing
- `pytest -q`
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_684ed95b01a88330af83aae8737914d8