### PR TITLE
Fix xlsx preview failure

### DIFF
--- a/portfolio-api/src/services/xlsx_import.py
+++ b/portfolio-api/src/services/xlsx_import.py
@@ -6,7 +6,7 @@ REQUIRED_COLS = ["Datum", "Typ", "Namn", "Antal/Belopp", "Kurs", "Belopp", "Valu
 
 
 def parse_xlsx(file_obj):
-    df = pd.read_excel(file_obj, engine=None)
+    df = pd.read_excel(file_obj, engine="openpyxl")
     cols = list(df.columns)
     if not all(c in cols for c in REQUIRED_COLS):
         raise ValueError("Missing required columns")


### PR DESCRIPTION
## Summary
- use `openpyxl` engine when parsing uploaded Excel files

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684eec96bff88330a240f6800f023de4