### PR TITLE
Improve XLSX import error handling

### DIFF
--- a/portfolio-api/src/routes/import_routes.py
+++ b/portfolio-api/src/routes/import_routes.py
@@ -5,6 +5,7 @@ from src.lib.fx import validate_currency_code
 from src.models.user import db
 from src.services.google_finance import parse_raw
 from src.services.xlsx_import import parse_xlsx
+from werkzeug.exceptions import BadRequest
 from src.importers.avanza_text import detect_avanza_text, parse_avanza_text
 
 import_bp = Blueprint('import', __name__)
@@ -77,5 +78,8 @@ def xlsx_preview():
     file = request.files.get('file')
     if not file:
         return jsonify({'error': 'No file uploaded'}), 400
-    rows, invalid = parse_xlsx(file)
+    try:
+        rows, invalid = parse_xlsx(file)
+    except ValueError as exc:
+        raise BadRequest(str(exc)) from exc
     return jsonify({"rows": rows, "invalid_rows": invalid})

--- a/portfolio-api/tests/test_xlsx_import.py
+++ b/portfolio-api/tests/test_xlsx_import.py
@@ -1,0 +1,14 @@
+import pandas as pd
+import pytest
+
+from src.services.xlsx_import import parse_xlsx
+
+
+def test_missing_headers(tmp_path, app):
+    df = pd.DataFrame({"Date": ["2025-06-15"], "Symbol": ["AAPL"]})
+    bad_file = tmp_path / "bad.xlsx"
+    df.to_excel(bad_file, index=False)
+
+    with app.app_context():
+        with pytest.raises(ValueError, match="Missing required columns"):
+            parse_xlsx(bad_file)


### PR DESCRIPTION
## Summary
- log missing columns and raise a clear error from `parse_xlsx`
- return HTTP 400 if `parse_xlsx` fails in the import route
- add regression test for missing columns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684f0b62ea1083309f565823bd1b03f9