### PR TITLE
Fix price refresh button

### DIFF
--- a/portfolio-api/src/main.py
+++ b/portfolio-api/src/main.py
@@ -8,7 +8,7 @@ from flask_cors import CORS
 from src.models.user import db
 from src.models.portfolio import Stock, Transaction
 from src.routes.user import user_bp
-from src.routes.portfolio import portfolio_bp
+from src.routes.portfolio import portfolio_bp, prices_bp
 from src.routes.import_routes import import_bp
 from src.routes.fx import fx_bp
 from src.config import SQLALCHEMY_DATABASE_URI
@@ -24,6 +24,7 @@ app.config['BASE_CURRENCY'] = PORTFOLIO_BASE_CCY
 
 app.register_blueprint(user_bp, url_prefix='/api')
 app.register_blueprint(portfolio_bp, url_prefix='/api/portfolio')
+app.register_blueprint(prices_bp, url_prefix='/api/prices')
 app.register_blueprint(import_bp, url_prefix='/api/import')
 app.register_blueprint(fx_bp, url_prefix='/api/fx')
 

--- a/portfolio-api/tests/conftest.py
+++ b/portfolio-api/tests/conftest.py
@@ -10,7 +10,7 @@ import pytest
 from flask import Flask
 from src.models.user import db
 from src.routes.user import user_bp
-from src.routes.portfolio import portfolio_bp
+from src.routes.portfolio import portfolio_bp, prices_bp
 from src.routes.import_routes import import_bp
 from src.routes.fx import fx_bp
 
@@ -26,6 +26,7 @@ def app():
         db.create_all()
     app.register_blueprint(user_bp, url_prefix='/api')
     app.register_blueprint(portfolio_bp, url_prefix='/api/portfolio')
+    app.register_blueprint(prices_bp, url_prefix='/api/prices')
     app.register_blueprint(import_bp, url_prefix='/api/import')
     app.register_blueprint(fx_bp, url_prefix='/api/fx')
     yield app

--- a/portfolio-api/tests/test_portfolio_endpoints.py
+++ b/portfolio-api/tests/test_portfolio_endpoints.py
@@ -256,19 +256,10 @@ def test_update_price_includes_company(client, monkeypatch):
     }
     client.post('/api/portfolio/transactions', json=tx)
 
-    fake_chart = {
-        'chart': {
-            'result': [{
-                'meta': {
-                    'regularMarketPrice': 150.0,
-                    'longName': 'Apple Inc.'
-                }
-            }]
-        }
-    }
-    monkeypatch.setattr('src.routes.portfolio.client.call_api', lambda *a, **k: fake_chart)
+    monkeypatch.setattr('src.routes.portfolio.fetch_quote', lambda s: 150.0)
+    monkeypatch.setattr('src.lib.market_data.get_company_name', lambda s: 'Apple Inc.')
 
-    resp = client.post('/api/portfolio/stocks/AAPL/price')
+    resp = client.post('/api/prices/update?symbol=AAPL')
     assert resp.status_code == 200
     body = resp.get_json()
     assert body['company'] == 'Apple Inc.'

--- a/portfolio-tracker/src/lib/api.ts
+++ b/portfolio-tracker/src/lib/api.ts
@@ -24,6 +24,8 @@ export const searchStock = (s: string) =>
   fetch(`${BASE}/stocks/search/${encodeURIComponent(s)}`)
 export const fetchCurrentPrice = (symbol: string) =>
   fetch(`${BASE}/stocks/${encodeURIComponent(symbol)}`)
+export const updatePrice = (symbol: string) =>
+  post(`/prices/update?symbol=${encodeURIComponent(symbol)}`, {})
 export const addTransaction = (body: any) =>
   fetch(`${BASE}/transactions`, {
     method: 'POST',


### PR DESCRIPTION
## Summary
- add prices blueprint for single price updates
- expose `/api/prices/update` endpoint
- use new endpoint in StockHoldings
- show toast when refreshing a price
- add API helper for updating prices
- adjust tests for new endpoint

## Testing
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68506d1452148330a0150ee0b22d60b6