### PR TITLE
Fix single price update route

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The app will be available at the printed Vite dev server address (usually `http:
 | `GET /api/portfolio/stocks` | Get all portfolio stocks |
 | `GET /api/portfolio/stocks/<symbol>` | Get stock details |
 | `POST /api/portfolio/stocks/<symbol>/price` | Refresh a stock price |
+| `POST /api/portfolio/prices/update?symbol=<symbol>` | Update cached price |
 | `GET /api/portfolio/transactions` | List all transactions |
 | `POST /api/portfolio/transactions` | Add a transaction |
 | `DELETE /api/portfolio/transactions/<id>` | Delete a transaction |

--- a/portfolio-api/src/routes/portfolio.py
+++ b/portfolio-api/src/routes/portfolio.py
@@ -219,6 +219,7 @@ def update_stock_price(symbol):
         return jsonify({'error': str(e)}), 500
 
 
+@portfolio_bp.route('/prices/update', methods=['POST'])
 @prices_bp.route('/update', methods=['POST'])
 def update_price():
     """Update a single stock price using the quote service.

--- a/portfolio-api/tests/test_portfolio_endpoints.py
+++ b/portfolio-api/tests/test_portfolio_endpoints.py
@@ -265,6 +265,26 @@ def test_update_price_includes_company(client, monkeypatch):
     assert body['company'] == 'Apple Inc.'
 
 
+def test_update_price_alias(client, monkeypatch):
+    tx = {
+        'symbol': 'GOOG',
+        'transaction_type': 'buy',
+        'quantity': 1,
+        'price_per_share': 200.0,
+        'transaction_date': '2024-01-01'
+    }
+    client.post('/api/portfolio/transactions', json=tx)
+
+    monkeypatch.setattr('src.routes.portfolio.fetch_quote', lambda s: 250.0)
+    monkeypatch.setattr('src.lib.market_data.get_company_name', lambda s: 'Google LLC')
+
+    resp = client.post('/api/portfolio/prices/update?symbol=GOOG')
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data['current_price'] == 250.0
+    assert data['company'] == 'Google LLC'
+
+
 def test_buy_fee_affects_avg_cost(client, monkeypatch):
     monkeypatch.setattr('src.routes.portfolio.get_fx_rate', lambda *a, **k: 1.0)
 


### PR DESCRIPTION
## Summary
- handle POST /api/portfolio/prices/update
- document price update alias
- test alias endpoint

## Testing
- `pytest -q`
- `pytest portfolio-api/tests/test_portfolio_endpoints.py::test_update_price_alias -q`


------
https://chatgpt.com/codex/tasks/task_e_685261c0435483308b3bf2b2e6a4a1b7