### PR TITLE
Move fees toggle to header

### DIFF
--- a/portfolio-tracker/src/components/Header.jsx
+++ b/portfolio-tracker/src/components/Header.jsx
@@ -1,12 +1,14 @@
 import { Button } from '@/components/ui/button.jsx'
 import { Select, SelectTrigger, SelectContent, SelectItem, SelectValue } from '@/components/ui/select.jsx'
 import { RefreshCw } from 'lucide-react'
+import { Switch } from '@/components/ui/switch.jsx'
+import { Label } from '@/components/ui/label.jsx'
 import { useSettings } from '@/store/settingsSlice'
 
 const CURRENCIES = ['USD','EUR','GBP','SEK','PLN','JPY']
 
 export default function Header({ onUpdatePrices, loading }) {
-  const { baseCurrency, setBaseCurrency } = useSettings()
+  const { baseCurrency, setBaseCurrency, includeFees, setIncludeFees } = useSettings()
   return (
     <div className="flex justify-between items-center mb-8">
       <div>
@@ -33,6 +35,8 @@ export default function Header({ onUpdatePrices, loading }) {
           <RefreshCw className={`h-4 w-4 ${loading ? 'animate-spin' : ''}`} />
           Update Prices
         </Button>
+        <Label htmlFor="fees-toggle">Show fees:</Label>
+        <Switch id="fees-toggle" checked={includeFees} onCheckedChange={setIncludeFees} />
       </div>
     </div>
   )

--- a/portfolio-tracker/src/components/PortfolioSummary.jsx
+++ b/portfolio-tracker/src/components/PortfolioSummary.jsx
@@ -94,17 +94,6 @@ function PortfolioSummary({ summary }) {
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-          <CardTitle className="text-sm font-medium">Include fees in performance</CardTitle>
-          <Switch checked={includeFees} onCheckedChange={setIncludeFees} id="fees-toggle" />
-        </CardHeader>
-        <CardContent>
-          <p className="text-xs text-muted-foreground">
-            Toggle to subtract fees when calculating gains
-          </p>
-        </CardContent>
-      </Card>
     </div>
   )
 }

--- a/portfolio-tracker/tests/feesToggle.test.tsx
+++ b/portfolio-tracker/tests/feesToggle.test.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import { render, screen } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import StockHoldings from '../src/components/StockHoldings'
-import PortfolioSummary from '../src/components/PortfolioSummary'
+import Header from '../src/components/Header.jsx'
 import { SettingsProvider } from '../src/store/settingsSlice'
 import { jest } from '@jest/globals'
 
@@ -29,21 +29,12 @@ const holdings = [
   },
 ]
 
-const summary = {
-  total_value: 150,
-  total_cost_basis: 100,
-  total_gain: 50,
-  total_gain_percent: 50,
-  total_fees_paid: 2,
-  net_gain_after_fees: 48,
-  stocks_count: 1,
-}
 
 test('gain switches when fees toggle flipped', async () => {
   const user = userEvent.setup()
   render(
     <SettingsProvider>
-      <PortfolioSummary summary={summary} />
+      <Header onUpdatePrices={() => {}} loading={false} />
       <StockHoldings portfolioData={holdings} onRefresh={() => {}} loading={false} />
     </SettingsProvider>
   )


### PR DESCRIPTION
## Summary
- place Include Fees toggle inline in the header
- remove the large toggle card from PortfolioSummary
- update fees toggle test to use the header control

## Testing
- `npm test -- -w=1`

------
https://chatgpt.com/codex/tasks/task_e_68528200d5b88330b50f3c985427746b