### PR TITLE
Add Stooq fallback for quotes

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+FALLBACK_PROVIDER=stooq

--- a/README.md
+++ b/README.md
@@ -37,6 +37,13 @@ the version like `v4e96b97` corresponding to the commit used for the build.
 
 The API reads optional environment variables like `SECRET_KEY`, `DATABASE_URL` and `PORTFOLIO_BASE_CCY`. Default values are provided so it will start without extra configuration. Historical price lookups use the minimal `ApiClient` in `portfolio-api/src/data_api.py`. To enable live quote lookups via Alpha Vantage set `ALPHAVANTAGE_API_KEY`.
 
+### Data Providers
+
+Historical prices and company lookups come from Manus API Hub (Yahoo Finance).
+When `ALPHAVANTAGE_API_KEY` is set the API will query Alpha Vantage for live
+quotes. If a symbol is not available there, it falls back to [Stooq](https://stooq.com).
+Set `FALLBACK_PROVIDER=stooq` in your `.env` to enable this behaviour.
+
 # My Portfolio
 
 This repository contains a Flask API and a React front-end for tracking investment portfolios.

--- a/portfolio-api/src/services/providers/stooq.py
+++ b/portfolio-api/src/services/providers/stooq.py
@@ -1,0 +1,15 @@
+import io
+import pandas as pd
+import requests
+
+
+def fetch_quote(symbol: str):
+    """Return latest closing price from Stooq or ``None`` if unavailable."""
+    stooq_symbol = symbol.split('.')[0].lower()
+    url = f"https://stooq.com/q/l/?s={stooq_symbol}&f=sd2t2ohlcv&h&e=csv"
+    resp = requests.get(url, timeout=10)
+    resp.raise_for_status()
+    df = pd.read_csv(io.StringIO(resp.text))
+    if df.empty or df['Close'].isna().iloc[0]:
+        return None
+    return float(df['Close'].iloc[0])

--- a/portfolio-api/tests/stubs/stooq_cig.csv
+++ b/portfolio-api/tests/stubs/stooq_cig.csv
@@ -1,0 +1,2 @@
+Symbol,Date,Time,Open,High,Low,Close,Volume
+cig,2024-06-17,17:00,4.45,4.55,4.41,4.50,15000

--- a/portfolio-api/tests/test_market_data.py
+++ b/portfolio-api/tests/test_market_data.py
@@ -1,5 +1,7 @@
 import json
+from pathlib import Path
 from src.services import market_data
+from src.services.providers import stooq
 from src.lib import market_data as lib_market_data
 
 
@@ -42,3 +44,31 @@ def test_get_company_name(monkeypatch):
 
     name = market_data.get_company_name("AAPL")
     assert name == "Apple Inc"
+
+
+def test_fetch_quote_fallback(monkeypatch):
+    market_data._CACHE.clear()
+    monkeypatch.setenv('ALPHAVANTAGE_API_KEY', 'demo')
+
+    def fake_av_get(url, params=None, **kwargs):
+        class R:
+            def raise_for_status(self):
+                pass
+            def json(self):
+                return {'Error Message': 'Invalid'}
+        return R()
+
+    sample = Path('portfolio-api/tests/stubs/stooq_cig.csv').read_text()
+    def fake_stooq_get(url, timeout=10):
+        class R:
+            text = sample
+            def raise_for_status(self):
+                pass
+        return R()
+
+    import types
+    monkeypatch.setattr(market_data, 'requests', types.SimpleNamespace(get=fake_av_get))
+    monkeypatch.setattr(stooq, 'requests', types.SimpleNamespace(get=fake_stooq_get))
+
+    price = market_data.fetch_quote('CIG.WA')
+    assert price == 4.50

--- a/portfolio-api/tests/test_portfolio_endpoints.py
+++ b/portfolio-api/tests/test_portfolio_endpoints.py
@@ -213,7 +213,10 @@ def test_search_missing(client, monkeypatch):
     assert r.get_json()["message"] == "symbol not found"
 
 
-def test_search_not_found(client):
+def test_search_not_found(client, monkeypatch):
+    from src.services.providers import stooq
+    monkeypatch.setattr(stooq, 'fetch_quote', lambda s: None)
+
     r = client.get('/api/portfolio/stocks/search/FOO')
     assert r.status_code == 404
 

--- a/portfolio-api/tests/test_stooq_provider.py
+++ b/portfolio-api/tests/test_stooq_provider.py
@@ -1,0 +1,18 @@
+from pathlib import Path
+from src.services.providers import stooq
+
+
+def test_fetch_stooq(monkeypatch):
+    sample = Path('portfolio-api/tests/stubs/stooq_cig.csv').read_text()
+
+    def fake_get(url, timeout=10):
+        class R:
+            text = sample
+            def raise_for_status(self):
+                pass
+        return R()
+
+    monkeypatch.setattr(stooq.requests, 'get', fake_get)
+
+    price = stooq.fetch_quote('CIG.WA')
+    assert price == 4.50


### PR DESCRIPTION
## Summary
- support fallback provider using Stooq when AlphaVantage has no data
- record fallback provider in `.env`
- document new provider setup in README
- test Stooq provider and fallback logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852b29248448330978728be9fd60935