### PR TITLE
Add ExchangeRate model

### DIFF
--- a/portfolio-api/src/lib/fx.py
+++ b/portfolio-api/src/lib/fx.py
@@ -5,7 +5,7 @@ import os
 import requests
 from flask import current_app
 
-from src.models.portfolio import FxRate
+from src.models.portfolio import ExchangeRate
 from src.models.user import db
 
 
@@ -41,7 +41,7 @@ def get_fx_rate(from_ccy: str, to_ccy: str, dt: Union[str, date_cls]) -> float:
     if from_ccy == to_ccy:
         return 1.0
 
-    rate = FxRate.query.filter_by(base=from_ccy, target=to_ccy, date=dt).first()
+    rate = ExchangeRate.query.filter_by(base=from_ccy, quote=to_ccy, date=dt).first()
     if rate:
         return rate.rate
 
@@ -71,7 +71,7 @@ def get_fx_rate(from_ccy: str, to_ccy: str, dt: Union[str, date_cls]) -> float:
         current_app.logger.exception("FX fetch failed: %s", exc)
         raise FxDownloadError("unreachable") from exc
 
-    db.session.add(FxRate(base=from_ccy, target=to_ccy, date=dt, rate=fx))
+    db.session.add(ExchangeRate(base=from_ccy, quote=to_ccy, date=dt, rate=fx))
     db.session.commit()
 
     return fx

--- a/portfolio-api/src/models/portfolio.py
+++ b/portfolio-api/src/models/portfolio.py
@@ -97,17 +97,19 @@ class PriceCache(db.Model):
         return f"<PriceCache {self.symbol} {self.price} {self.currency.value}>"
 
 
-class FxRate(db.Model):
-    __tablename__ = "fx_rates"
+class ExchangeRate(db.Model):
+    __tablename__ = "exchange_rates"
 
     id = db.Column(db.Integer, primary_key=True)
     base = db.Column(db.String(3), nullable=False)
-    target = db.Column(db.String(3), nullable=False)
+    quote = db.Column(db.String(3), nullable=False)
     date = db.Column(db.Date, nullable=False)
     rate = db.Column(db.Float, nullable=False)
 
-    __table_args__ = (db.UniqueConstraint("base", "target", "date", name="uix_fx"),)
+    __table_args__ = (
+        db.UniqueConstraint("base", "quote", "date", name="uix_exchange_rate"),
+    )
 
     def __repr__(self):
-        return f"<FxRate {self.base}->{self.target} {self.date} {self.rate}>"
+        return f"<ExchangeRate {self.base}->{self.quote} {self.date} {self.rate}>"
 

--- a/portfolio-api/src/routes/fx.py
+++ b/portfolio-api/src/routes/fx.py
@@ -1,6 +1,6 @@
 from datetime import date
 from flask import Blueprint, request, jsonify
-from src.models.portfolio import FxRate
+from src.models.portfolio import ExchangeRate
 from src.models.user import db
 from src.lib.fx import validate_currency_code
 
@@ -13,10 +13,10 @@ def manual_rate():
     quote = validate_currency_code(data.get('quote', ''))
     rate = float(data['rate'])
     today = date.today()
-    rec = FxRate.query.filter_by(base=base, target=quote, date=today).first()
+    rec = ExchangeRate.query.filter_by(base=base, quote=quote, date=today).first()
     if rec:
         rec.rate = rate
     else:
-        db.session.add(FxRate(base=base, target=quote, date=today, rate=rate))
+        db.session.add(ExchangeRate(base=base, quote=quote, date=today, rate=rate))
     db.session.commit()
     return jsonify({'base': base, 'quote': quote, 'rate': rate})

--- a/portfolio-api/tests/test_portfolio_endpoints.py
+++ b/portfolio-api/tests/test_portfolio_endpoints.py
@@ -161,8 +161,8 @@ def test_currency_conversion(client, monkeypatch, app):
     assert round(data['total_cost_basis'], 2) == 220.0
 
     with app.app_context():
-        from src.models.portfolio import FxRate
-        assert FxRate.query.count() == 1
+        from src.models.portfolio import ExchangeRate
+        assert ExchangeRate.query.count() == 1
 
 
 def test_portfolio_history(client, app):
@@ -476,7 +476,7 @@ def test_manual_fx_endpoint(client, app):
     resp = client.post('/api/fx/manual', json=data)
     assert resp.status_code == 200
     with app.app_context():
-        from src.models.portfolio import FxRate
+        from src.models.portfolio import ExchangeRate
         from datetime import date
-        rec = FxRate.query.filter_by(base='USD', target='SEK', date=date.today()).first()
+        rec = ExchangeRate.query.filter_by(base='USD', quote='SEK', date=date.today()).first()
         assert rec and rec.rate == 10.46


### PR DESCRIPTION
## Summary
- replace `FxRate` with new `ExchangeRate` model
- update FX utilities and endpoint to use `ExchangeRate`
- adjust tests for new model name

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c14ece688330aecffbf2db81d240