### PR TITLE
Implement FX override API

### DIFF
--- a/portfolio-api/src/models/portfolio.py
+++ b/portfolio-api/src/models/portfolio.py
@@ -105,6 +105,7 @@ class ExchangeRate(db.Model):
     quote = db.Column(db.String(3), nullable=False)
     date = db.Column(db.Date, nullable=False)
     rate = db.Column(db.Float, nullable=False)
+    source = db.Column(db.String(32), nullable=True)
 
     __table_args__ = (
         db.UniqueConstraint("base", "quote", "date", name="uix_exchange_rate"),

--- a/portfolio-api/src/routes/fx.py
+++ b/portfolio-api/src/routes/fx.py
@@ -6,17 +6,20 @@ from src.lib.fx import validate_currency_code
 
 fx_bp = Blueprint('fx', __name__)
 
-@fx_bp.route('/manual', methods=['POST'])
+@fx_bp.route('/override', methods=['POST'])
 def manual_rate():
     data = request.get_json(force=True)
     base = validate_currency_code(data.get('base', ''))
     quote = validate_currency_code(data.get('quote', ''))
     rate = float(data['rate'])
-    today = date.today()
-    rec = ExchangeRate.query.filter_by(base=base, quote=quote, date=today).first()
+    dt = date.fromisoformat(data['date'])
+    rec = ExchangeRate.query.filter_by(base=base, quote=quote, date=dt).first()
     if rec:
         rec.rate = rate
+        rec.source = 'manual'
     else:
-        db.session.add(ExchangeRate(base=base, quote=quote, date=today, rate=rate))
+        db.session.add(
+            ExchangeRate(base=base, quote=quote, date=dt, rate=rate, source='manual')
+        )
     db.session.commit()
-    return jsonify({'base': base, 'quote': quote, 'rate': rate})
+    return jsonify({'date': dt.isoformat(), 'base': base, 'quote': quote, 'rate': rate})

--- a/portfolio-api/tests/test_portfolio_endpoints.py
+++ b/portfolio-api/tests/test_portfolio_endpoints.py
@@ -472,11 +472,12 @@ def test_fx_fetch_quota_exceeded(client, monkeypatch, app):
 
 
 def test_manual_fx_endpoint(client, app):
-    data = {'base': 'USD', 'quote': 'SEK', 'rate': 10.46}
-    resp = client.post('/api/fx/manual', json=data)
+    from datetime import date as date_cls
+    today = date_cls.today().isoformat()
+    data = {'date': today, 'base': 'USD', 'quote': 'SEK', 'rate': 10.46}
+    resp = client.post('/api/fx/override', json=data)
     assert resp.status_code == 200
     with app.app_context():
         from src.models.portfolio import ExchangeRate
-        from datetime import date
-        rec = ExchangeRate.query.filter_by(base='USD', quote='SEK', date=date.today()).first()
-        assert rec and rec.rate == 10.46
+        rec = ExchangeRate.query.filter_by(base='USD', quote='SEK', date=date_cls.fromisoformat(today)).first()
+        assert rec and rec.rate == 10.46 and rec.source == 'manual'


### PR DESCRIPTION
## Summary
- add `source` column to `ExchangeRate`
- add `/api/fx/override` endpoint to upsert manual FX rates
- test manual FX override

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852c4acd7588330b253422e2f87eca3