### PR TITLE
Add FX refresh task

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ The HTML page used for quick testing of these endpoints has been moved to
 2. Use the web interface to add transactions (choose a currency for each entry) and view holdings.
 3. Call the API directly (e.g., using `curl` or Postman) to integrate with other tools.
 4. Update prices periodically using the "Update Prices" button or the corresponding API endpoint.
+5. Refresh foreign exchange rates daily by running `python -m src.tasks.refresh_fx` in a scheduled job.
 
 ## Import trades
 

--- a/portfolio-api/src/tasks/refresh_fx.py
+++ b/portfolio-api/src/tasks/refresh_fx.py
@@ -1,0 +1,40 @@
+"""Fetch and store FX rates for a given date.
+
+This task mirrors the behaviour of the `/api/fx/refresh` endpoint but can be
+run as a standalone script or scheduled job.
+"""
+
+from __future__ import annotations
+
+import os
+from datetime import date
+
+from flask import Flask
+
+from src.config import SQLALCHEMY_DATABASE_URI, PORTFOLIO_BASE_CCY
+from src.models.user import db
+from src.services.fx import ensure_fx_rates
+
+
+def create_app() -> Flask:
+    app = Flask("refresh-fx")
+    app.config["SQLALCHEMY_DATABASE_URI"] = os.environ.get(
+        "DATABASE_URL", SQLALCHEMY_DATABASE_URI
+    )
+    app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
+    db.init_app(app)
+    return app
+
+
+def refresh_fx(target_date: date) -> None:
+    """Download FX rates for ``target_date`` and save them to the DB."""
+    app = create_app()
+    with app.app_context():
+        db.create_all()
+        base_currency = os.environ.get("PORTFOLIO_BASE_CCY", PORTFOLIO_BASE_CCY)
+        ensure_fx_rates(target_date, base_currency)
+        print(f"FX rates refreshed for {target_date.isoformat()}", flush=True)
+
+
+if __name__ == "__main__":
+    refresh_fx(date.today())

--- a/portfolio-api/tests/test_refresh_fx_task.py
+++ b/portfolio-api/tests/test_refresh_fx_task.py
@@ -1,0 +1,14 @@
+from datetime import date
+
+def test_refresh_fx_calls_service(monkeypatch):
+    called = {}
+    def fake_ensure(dt, base):
+        called['dt'] = dt
+        called['base'] = base
+    monkeypatch.setattr('src.services.fx.ensure_fx_rates', fake_ensure)
+    monkeypatch.setenv('DATABASE_URL', 'sqlite:///:memory:')
+    monkeypatch.setenv('PORTFOLIO_BASE_CCY', 'USD')
+
+    from src.tasks.refresh_fx import refresh_fx
+    refresh_fx(date(2024, 1, 2))
+    assert called == {'dt': date(2024, 1, 2), 'base': 'USD'}


### PR DESCRIPTION
## Summary
- add `refresh_fx` background task
- document how to run it
- test that the task invokes the FX service

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852db59c13c833081673a806014e214