### PR TITLE
Add fx service tests and cached summary integration

### DIFF
--- a/portfolio-api/tests/test_summary_cached_fx.py
+++ b/portfolio-api/tests/test_summary_cached_fx.py
@@ -1,0 +1,37 @@
+from datetime import date
+
+from src.models.user import db
+from src.models.portfolio import Stock, Transaction, ExchangeRate
+
+
+def test_summary_uses_cached_fx(client, app, monkeypatch):
+    with app.app_context():
+        stock = Stock(symbol="AAPL")
+        db.session.add(stock)
+        db.session.add(Transaction(
+            stock=stock,
+            transaction_type="buy",
+            quantity=1,
+            price_per_share=100.0,
+            currency="EUR",
+            transaction_date=date(2025, 5, 14),
+        ))
+        db.session.add(ExchangeRate(
+            base="EUR",
+            quote="USD",
+            date=date(2025, 5, 14),
+            rate=1.1,
+        ))
+        db.session.commit()
+
+    def fail_fetch(*args, **kwargs):
+        raise AssertionError("external FX called")
+
+    monkeypatch.setattr("src.routes.portfolio.get_fx_rate", fail_fetch)
+    monkeypatch.setattr("src.services.fx._fetch_rates", fail_fetch)
+
+    resp = client.get("/api/portfolio/summary")
+    assert resp.status_code == 200
+    data = resp.get_json()
+    assert data["base_currency"] == "USD"
+    assert data["total_cost_basis"] == 110.0


### PR DESCRIPTION
## Summary
- extend fx service tests with provider failure scenario
- add integration test to ensure summary uses cached FX rates

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6852db7d881c8330b4f6fd7dafeff06a