### PR TITLE
Add timeframe tabs with zustand state

### DIFF
--- a/portfolio-tracker/package.json
+++ b/portfolio-tracker/package.json
@@ -47,6 +47,7 @@
     "framer-motion": "^12.15.0",
     "input-otp": "^1.4.2",
     "lucide-react": "^0.510.0",
+    "luxon": "^3.6.1",
     "next-themes": "^0.4.6",
     "react": "^19.1.0",
     "react-day-picker": "^9.7.0",
@@ -59,7 +60,8 @@
     "tailwind-merge": "^3.3.0",
     "tailwindcss": "^4.1.7",
     "vaul": "^1.1.2",
-    "zod": "^3.24.4"
+    "zod": "^3.24.4",
+    "zustand": "^5.0.5"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.27.2",

--- a/portfolio-tracker/pnpm-lock.yaml
+++ b/portfolio-tracker/pnpm-lock.yaml
@@ -116,6 +116,9 @@ importers:
       lucide-react:
         specifier: ^0.510.0
         version: 0.510.0(react@19.1.0)
+      luxon:
+        specifier: ^3.6.1
+        version: 3.6.1
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -155,6 +158,9 @@ importers:
       zod:
         specifier: ^3.24.4
         version: 3.25.64
+      zustand:
+        specifier: ^5.0.5
+        version: 5.0.5(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0))
     devDependencies:
       '@babel/preset-env':
         specifier: ^7.27.2
@@ -3410,6 +3416,10 @@ packages:
     peerDependencies:
       react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
+  luxon@3.6.1:
+    resolution: {integrity: sha512-tJLxrKJhO2ukZ5z0gyjY1zPh3Rh88Ej9P7jNrZiHMUXHae1yvI2imgOZtL1TO8TW6biMMKfTtAOoEJANgtWBMQ==}
+    engines: {node: '>=12'}
+
   lz-string@1.5.0:
     resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
     hasBin: true
@@ -4209,6 +4219,24 @@ packages:
 
   zod@3.25.64:
     resolution: {integrity: sha512-hbP9FpSZf7pkS7hRVUrOjhwKJNyampPgtXKc3AN6DsWtoHsg2Sb4SQaS4Tcay380zSwd2VPo9G9180emBACp5g==}
+
+  zustand@5.0.5:
+    resolution: {integrity: sha512-mILtRfKW9xM47hqxGIxCv12gXusoY/xTSHBYApXozR0HmQv299whhBeeAcRy+KrPPybzosvJBCOmVjq6x12fCg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
 
 snapshots:
 
@@ -7749,6 +7777,8 @@ snapshots:
     dependencies:
       react: 19.1.0
 
+  luxon@3.6.1: {}
+
   lz-string@1.5.0: {}
 
   magic-string@0.30.17:
@@ -8484,3 +8514,9 @@ snapshots:
   yocto-queue@0.1.0: {}
 
   zod@3.25.64: {}
+
+  zustand@5.0.5(@types/react@19.1.8)(react@19.1.0)(use-sync-external-store@1.5.0(react@19.1.0)):
+    optionalDependencies:
+      '@types/react': 19.1.8
+      react: 19.1.0
+      use-sync-external-store: 1.5.0(react@19.1.0)

--- a/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
+++ b/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
@@ -1,32 +1,22 @@
-import { useState, useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Switch } from '@/components/ui/switch.jsx'
-import { get } from '@/lib/api'
+import { DateTime } from 'luxon'
+import { usePortfolioStore } from '@/store/portfolioStore'
+import TimeFrameTabs from './TimeFrameTabs'
 
 function PortfolioHistoryChart() {
-  const [history, setHistory] = useState([])
   const [includeContributions, setIncludeContributions] = useState(true)
+  const { history, fetchHistory } = usePortfolioStore()
 
   useEffect(() => {
-    const fetchHistory = async () => {
-      try {
-        const resp = await get('/history')
-        if (resp.ok) {
-          const data = await resp.json()
-          setHistory(data)
-        }
-      } catch (err) {
-        console.error('Error fetching portfolio history:', err)
-      }
-    }
-
     fetchHistory()
-  }, [])
+  }, [fetchHistory])
 
   const formatted = history.map((item) => ({
     ...item,
-    date: new Date(item.date).toLocaleDateString()
+    date: DateTime.fromISO(item.date).toLocaleString(DateTime.DATE_SHORT)
   }))
 
   const lineKey = includeContributions ? 'with_contributions' : 'market_value_only'
@@ -50,6 +40,7 @@ function PortfolioHistoryChart() {
           <CardTitle>Portfolio Value</CardTitle>
           <CardDescription>Historical portfolio value</CardDescription>
         </div>
+        <TimeFrameTabs />
         <div className="flex items-center space-x-2 text-sm">
           <Switch
             checked={includeContributions}

--- a/portfolio-tracker/src/components/TimeFrameTabs.tsx
+++ b/portfolio-tracker/src/components/TimeFrameTabs.tsx
@@ -1,0 +1,19 @@
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs.jsx'
+import { usePortfolioStore, TimeRange } from '@/store/portfolioStore'
+
+const ranges: TimeRange[] = ['1D', '5D', '1M', '6M', 'YTD', '1Y', '5Y', 'MAX']
+
+export default function TimeFrameTabs() {
+  const { selectedRange, setRange } = usePortfolioStore()
+  return (
+    <Tabs value={selectedRange} onValueChange={setRange} className="w-full">
+      <TabsList className="grid grid-cols-8 w-full sm:w-fit">
+        {ranges.map((r) => (
+          <TabsTrigger key={r} value={r} className="px-2">
+            {r}
+          </TabsTrigger>
+        ))}
+      </TabsList>
+    </Tabs>
+  )
+}

--- a/portfolio-tracker/src/store/portfolioStore.ts
+++ b/portfolio-tracker/src/store/portfolioStore.ts
@@ -1,0 +1,75 @@
+import { DateTime } from 'luxon'
+import { create } from 'zustand'
+import { get } from '@/lib/api'
+
+export type TimeRange = '1D' | '5D' | '1M' | '6M' | 'YTD' | '1Y' | '5Y' | 'MAX'
+
+export interface HistoryPoint {
+  date: string
+  market_value_only: number
+  with_contributions: number
+}
+
+interface PortfolioState {
+  history: HistoryPoint[]
+  loading: boolean
+  selectedRange: TimeRange
+  setRange: (r: TimeRange) => void
+  fetchHistory: () => Promise<void>
+}
+
+function calcRange(range: TimeRange) {
+  const now = DateTime.local().startOf('day')
+  let from = now
+  switch (range) {
+    case '1D':
+      from = now.minus({ days: 1 })
+      break
+    case '5D':
+      from = now.minus({ days: 5 })
+      break
+    case '1M':
+      from = now.minus({ months: 1 })
+      break
+    case '6M':
+      from = now.minus({ months: 6 })
+      break
+    case 'YTD':
+      from = DateTime.local(now.year, 1, 1)
+      break
+    case '1Y':
+      from = now.minus({ years: 1 })
+      break
+    case '5Y':
+      from = now.minus({ years: 5 })
+      break
+    case 'MAX':
+      from = DateTime.fromISO('1970-01-01')
+      break
+  }
+  return { from: from.toISODate(), to: now.toISODate() }
+}
+
+export const usePortfolioStore = create<PortfolioState>((set, get) => ({
+  history: [],
+  loading: false,
+  selectedRange: '1M',
+  setRange: (r) => {
+    set({ selectedRange: r })
+    get().fetchHistory()
+  },
+  fetchHistory: async () => {
+    const { selectedRange } = get()
+    const { from, to } = calcRange(selectedRange)
+    set({ loading: true })
+    try {
+      const resp = await get(`/history?start=${from}&end=${to}`)
+      if (resp.ok) {
+        const data = await resp.json()
+        set({ history: data })
+      }
+    } finally {
+      set({ loading: false })
+    }
+  },
+}))


### PR DESCRIPTION
## Summary
- add luxon and zustand packages
- add Zustand-based `usePortfolioStore` with time range logic
- add `TimeFrameTabs` component to pick ranges
- update `PortfolioHistoryChart` to use new store and luxon dates

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6853b17edd58833085a9158a99c5df95