### PR TITLE
Implement history API range shortcuts

### DIFF
--- a/portfolio-api/tests/test_portfolio_endpoints.py
+++ b/portfolio-api/tests/test_portfolio_endpoints.py
@@ -193,16 +193,18 @@ def test_portfolio_history(client, app):
     resp = client.get('/api/portfolio/history?start=2024-01-01&end=2024-02-05')
     assert resp.status_code == 200
     data = resp.get_json()
+    history = data['history']
+    assert data['last_updated']
 
     expected_len = (date(2024, 2, 5) - date(2024, 1, 1)).days + 1
-    assert len(data) == expected_len
+    assert len(history) == expected_len
 
-    assert data[0]['date'] == '2024-01-01'
-    assert data[0]['with_contributions'] == 110.0
-    assert data[0]['market_value_only'] == 10.0
+    assert history[0]['date'] == '2024-01-01'
+    assert history[0]['with_contributions'] == 110.0
+    assert history[0]['market_value_only'] == 10.0
 
-    assert data[-1]['with_contributions'] == 220.0
-    assert data[-1]['market_value_only'] == 20.0
+    assert history[-1]['with_contributions'] == 220.0
+    assert history[-1]['market_value_only'] == 20.0
 
 
 def test_search_missing(client, monkeypatch):

--- a/portfolio-tracker/src/store/portfolioStore.ts
+++ b/portfolio-tracker/src/store/portfolioStore.ts
@@ -1,5 +1,5 @@
-import { DateTime } from 'luxon'
 import { create } from 'zustand'
+import debounce from 'lodash.debounce'
 import { get } from '@/lib/api'
 
 export type TimeRange = '1D' | '5D' | '1M' | '6M' | 'YTD' | '1Y' | '5Y' | 'MAX'
@@ -14,62 +14,49 @@ interface PortfolioState {
   history: HistoryPoint[]
   loading: boolean
   selectedRange: TimeRange
+  initialValue: number
+  currentValue: number
+  lastUpdated?: string
   setRange: (r: TimeRange) => void
-  fetchHistory: () => Promise<void>
+  fetchHistory: (r?: TimeRange) => void
 }
 
-function calcRange(range: TimeRange) {
-  const now = DateTime.local().startOf('day')
-  let from = now
-  switch (range) {
-    case '1D':
-      from = now.minus({ days: 1 })
-      break
-    case '5D':
-      from = now.minus({ days: 5 })
-      break
-    case '1M':
-      from = now.minus({ months: 1 })
-      break
-    case '6M':
-      from = now.minus({ months: 6 })
-      break
-    case 'YTD':
-      from = DateTime.local(now.year, 1, 1)
-      break
-    case '1Y':
-      from = now.minus({ years: 1 })
-      break
-    case '5Y':
-      from = now.minus({ years: 5 })
-      break
-    case 'MAX':
-      from = DateTime.fromISO('1970-01-01')
-      break
-  }
-  return { from: from.toISODate(), to: now.toISODate() }
-}
 
-export const usePortfolioStore = create<PortfolioState>((set, get) => ({
-  history: [],
-  loading: false,
-  selectedRange: '1M',
-  setRange: (r) => {
-    set({ selectedRange: r })
-    get().fetchHistory()
-  },
-  fetchHistory: async () => {
-    const { selectedRange } = get()
-    const { from, to } = calcRange(selectedRange)
+export const usePortfolioStore = create<PortfolioState>((set, get) => {
+  const doFetch = async (r: TimeRange) => {
     set({ loading: true })
     try {
-      const resp = await get(`/history?start=${from}&end=${to}`)
+      const resp = await get(`/history?range=${r}`)
       if (resp.ok) {
         const data = await resp.json()
-        set({ history: data })
+        const history = data.history ?? []
+        set({
+          history,
+          lastUpdated: data.last_updated,
+          initialValue: history[0]?.with_contributions ?? 0,
+          currentValue: history[history.length - 1]?.with_contributions ?? 0,
+        })
       }
     } finally {
       set({ loading: false })
     }
-  },
-}))
+  }
+
+  const debounced = debounce(doFetch, 250)
+
+  return {
+    history: [],
+    loading: false,
+    selectedRange: '1M',
+    initialValue: 0,
+    currentValue: 0,
+    lastUpdated: undefined,
+    setRange: (r) => {
+      set({ selectedRange: r })
+      debounced(r)
+    },
+    fetchHistory: (r?: TimeRange) => {
+      debounced(r ?? get().selectedRange)
+    },
+  }
+})


### PR DESCRIPTION
## Summary
- add `parse_range` helper to compute date windows
- extend `/portfolio/history` API to accept `range` and return `last_updated`
- wire Zustand store to use new range API with debounced calls
- update history endpoint test

## Testing
- `pip install -q -r requirements-dev.txt`
- `pytest -q`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6853b6136d508330b4c677d517eeb9a4