### PR TITLE
Add dynamic portfolio header

### DIFF
--- a/portfolio-tracker/src/components/PortfolioHeader.tsx
+++ b/portfolio-tracker/src/components/PortfolioHeader.tsx
@@ -1,0 +1,49 @@
+import React, { useMemo } from 'react'
+import { usePortfolioStore } from '@/store/portfolioStore'
+import { useSettings } from '@/store/settingsSlice'
+import { getCurrencySymbol } from '@/lib/utils.js'
+import { ChevronUp, ChevronDown } from 'lucide-react'
+import { DateTime } from 'luxon'
+
+function Chip({ value }: { value: number }) {
+  const Icon = value >= 0 ? ChevronUp : ChevronDown
+  const color = value >= 0 ? 'text-green-600 bg-green-500/10' : 'text-red-600 bg-red-500/10'
+  const sign = value >= 0 ? '+' : ''
+  return (
+    <span className={`flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${color}`}> 
+      <Icon className="w-3 h-3" />
+      {sign}{value.toFixed(2)}%
+    </span>
+  )
+}
+
+export default function PortfolioHeader() {
+  const { history, selectedRange } = usePortfolioStore()
+  const { baseCurrency } = useSettings()
+  const { current, deltaPct, deltaEuro } = useMemo(() => {
+    if (!history.length) return { current: 0, deltaPct: 0, deltaEuro: 0 }
+    const first = history[0].with_contributions
+    const last = history[history.length - 1].with_contributions
+    const diff = last - first
+    const pct = first !== 0 ? (diff / first) * 100 : 0
+    return { current: last, deltaPct: pct, deltaEuro: diff }
+  }, [history])
+
+  const currency = getCurrencySymbol(baseCurrency)
+  const now = DateTime.local().toFormat('dd LLL, HH:mm ZZZ')
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline gap-2">
+        <h1 className="text-2xl font-bold">
+          {currency}{current.toLocaleString()}
+        </h1>
+        <Chip value={deltaPct} />
+        <small className="text-muted-foreground">
+          {deltaEuro >= 0 ? '+' : ''}{deltaEuro.toLocaleString()} {selectedRange}
+        </small>
+      </div>
+      <div className="text-xs text-muted-foreground">{now}</div>
+    </div>
+  )
+}

--- a/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
+++ b/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
@@ -1,10 +1,11 @@
 import { useEffect, useState } from 'react'
 import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
+import { Card, CardContent, CardHeader } from '@/components/ui/card.jsx'
 import { Switch } from '@/components/ui/switch.jsx'
 import { DateTime } from 'luxon'
 import { usePortfolioStore } from '@/store/portfolioStore'
 import TimeFrameTabs from './TimeFrameTabs'
+import PortfolioHeader from './PortfolioHeader'
 
 function PortfolioHistoryChart() {
   const [includeContributions, setIncludeContributions] = useState(true)
@@ -35,21 +36,20 @@ function PortfolioHistoryChart() {
 
   return (
     <Card>
-      <CardHeader className="flex flex-row items-center justify-between">
-        <div>
-          <CardTitle>Portfolio Value</CardTitle>
-          <CardDescription>Historical portfolio value</CardDescription>
-        </div>
-        <TimeFrameTabs />
-        <div className="flex items-center space-x-2 text-sm">
-          <Switch
-            checked={includeContributions}
-            onCheckedChange={setIncludeContributions}
-            id="history-toggle"
-          />
-          <label htmlFor="history-toggle">
-            {includeContributions ? 'Include' : 'Exclude'} contributions
-          </label>
+      <CardHeader className="space-y-4">
+        <PortfolioHeader />
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
+          <TimeFrameTabs />
+          <div className="flex items-center space-x-2 text-sm">
+            <Switch
+              checked={includeContributions}
+              onCheckedChange={setIncludeContributions}
+              id="history-toggle"
+            />
+            <label htmlFor="history-toggle">
+              {includeContributions ? 'Include' : 'Exclude'} contributions
+            </label>
+          </div>
         </div>
       </CardHeader>
       <CardContent>

--- a/portfolio-tracker/tests/portfolioHeader.test.tsx
+++ b/portfolio-tracker/tests/portfolioHeader.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import { render, screen } from '@testing-library/react'
+import { act } from 'react'
+import PortfolioHeader from '../src/components/PortfolioHeader'
+import { SettingsProvider, useSettings } from '../src/store/settingsSlice'
+import { usePortfolioStore } from '../src/store/portfolioStore'
+
+beforeEach(() => {
+  usePortfolioStore.setState({ history: [], selectedRange: '1M' })
+  localStorage.clear()
+})
+
+function Wrapper({ children }: { children?: React.ReactNode }) {
+  return <SettingsProvider>{children}</SettingsProvider>
+}
+
+function SetEUR() {
+  const { setBaseCurrency } = useSettings()
+  React.useEffect(() => {
+    setBaseCurrency('EUR')
+  }, [setBaseCurrency])
+  return null
+}
+
+test('shows current value and delta', () => {
+  act(() => {
+    usePortfolioStore.setState({
+      history: [
+        { date: '2025-06-18', market_value_only: 100, with_contributions: 100 },
+        { date: '2025-06-19', market_value_only: 110, with_contributions: 110 },
+      ],
+    })
+  })
+  render(
+    <Wrapper>
+      <SetEUR />
+      <PortfolioHeader />
+    </Wrapper>
+  )
+  expect(screen.getByRole('heading').textContent).toContain('€110')
+  expect(screen.getAllByText(/\+10/).length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary
- display current portfolio value and changes
- integrate `PortfolioHeader` into line chart
- test component delta calculations

## Testing
- `pnpm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853b61de3c48330ae3d6b842914fdb1