### PR TITLE
Add brushing and monthly reference lines

### DIFF
--- a/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
+++ b/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
@@ -1,23 +1,65 @@
-import { useEffect, useState } from 'react'
-import { LineChart, Line, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from 'recharts'
+import { useEffect, useState, useRef } from 'react'
+import {
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+  ReferenceLine,
+  Brush,
+} from 'recharts'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card.jsx'
 import { Switch } from '@/components/ui/switch.jsx'
 import { DateTime } from 'luxon'
 import { usePortfolioStore } from '@/store/portfolioStore'
+import { useSettings } from '@/store/settingsSlice'
+import { getCurrencySymbol } from '@/lib/utils.js'
 import TimeFrameTabs from './TimeFrameTabs'
 
 function PortfolioHistoryChart() {
   const [includeContributions, setIncludeContributions] = useState(true)
-  const { history, fetchHistory } = usePortfolioStore()
+  const [brushInfo, setBrushInfo] = useState(null)
+  const containerRef = useRef(null)
+  const { history, fetchHistory, selectedRange } = usePortfolioStore()
+  const { baseCurrency } = useSettings()
 
   useEffect(() => {
     fetchHistory()
   }, [fetchHistory])
 
+  useEffect(() => {
+    setBrushInfo(null)
+  }, [selectedRange])
+
+  useEffect(() => {
+    function handleKey(e) {
+      if (e.key === 'Escape') setBrushInfo(null)
+    }
+    function handleClick(e) {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setBrushInfo(null)
+      }
+    }
+    document.addEventListener('keydown', handleKey)
+    document.addEventListener('mousedown', handleClick)
+    return () => {
+      document.removeEventListener('keydown', handleKey)
+      document.removeEventListener('mousedown', handleClick)
+    }
+  }, [])
+
   const formatted = history.map((item) => ({
     ...item,
     date: DateTime.fromISO(item.date).toLocaleString(DateTime.DATE_SHORT)
   }))
+
+  const monthStarts = history
+    .filter((h) => DateTime.fromISO(h.date).day === 1)
+    .map((h) => DateTime.fromISO(h.date).toLocaleString(DateTime.DATE_SHORT))
+
+  const brushEnabled = ['1M', '6M', 'YTD', '1Y', '5Y', 'MAX'].includes(selectedRange)
 
   const lineKey = includeContributions ? 'with_contributions' : 'market_value_only'
 
@@ -31,6 +73,18 @@ function PortfolioHistoryChart() {
       )
     }
     return null
+  }
+
+  const handleBrushChange = (range) => {
+    if (range && typeof range.startIndex === 'number' && typeof range.endIndex === 'number') {
+      const start = formatted[range.startIndex][lineKey]
+      const end = formatted[range.endIndex][lineKey]
+      const delta = end - start
+      const pct = start ? (delta / start) * 100 : 0
+      setBrushInfo({ delta, pct })
+    } else {
+      setBrushInfo(null)
+    }
   }
 
   return (
@@ -53,14 +107,23 @@ function PortfolioHistoryChart() {
         </div>
       </CardHeader>
       <CardContent>
-        <div className="h-80">
+        <div ref={containerRef} className="h-80 relative">
+          {brushInfo && brushEnabled && (
+            <div className="absolute bottom-10 left-2 bg-white border rounded shadow px-2 py-1 text-xs">
+              {getCurrencySymbol(baseCurrency)}{brushInfo.delta.toLocaleString()} ({brushInfo.pct.toFixed(2)}%)
+            </div>
+          )}
           <ResponsiveContainer width="100%" height="100%">
             <LineChart data={formatted}>
               <CartesianGrid strokeDasharray="3 3" />
               <XAxis dataKey="date" />
               <YAxis />
               <Tooltip content={<CustomTooltip />} />
+              {monthStarts.map((d) => (
+                <ReferenceLine key={d} x={d} stroke="#ddd" strokeDasharray="3 3" />
+              ))}
               <Line type="monotone" dataKey={lineKey} stroke="#8884d8" dot={false} />
+              {brushEnabled && <Brush dataKey="date" onChange={handleBrushChange} />}
             </LineChart>
           </ResponsiveContainer>
         </div>


### PR DESCRIPTION
## Summary
- show vertical lines at month boundaries in the history chart
- add optional brush for ranges >=1M
- display a delta badge after brushing

## Testing
- `pytest -q`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6853b6989ac4833083aa38fa55bc5ea6