### PR TITLE
Improve portfolio chart a11y

### DIFF
--- a/portfolio-tracker/src/components/CustomTooltip.tsx
+++ b/portfolio-tracker/src/components/CustomTooltip.tsx
@@ -10,7 +10,7 @@ interface TooltipProps {
 export default function CustomTooltip({ active, payload, label }: TooltipProps) {
   if (active && payload?.[0] && label) {
     return (
-      <div className="rounded-md bg-white p-2 shadow">
+      <div role="tooltip" className="rounded-md bg-white p-2 shadow">
         <div className="font-semibold text-sm">
           {fmtCurrency(payload[0].value)}
         </div>

--- a/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
+++ b/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
@@ -67,7 +67,7 @@ function PortfolioHistoryChart() {
   const CustomTooltip = ({ active, payload, label }) => {
     if (active && payload && payload.length) {
       return (
-        <div className="bg-white p-2 border rounded shadow text-xs">
+        <div role="tooltip" className="bg-white p-2 border rounded shadow text-xs">
           <p className="font-medium">{label}</p>
           <p>${payload[0].value.toLocaleString()}</p>
         </div>
@@ -89,14 +89,14 @@ function PortfolioHistoryChart() {
   }
   return (
     <Card>
-      <CardHeader className="space-y-4">
+      <CardHeader
+        className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between"
+      >
         <PortfolioHeader
           includeContributions={includeContributions}
           setIncludeContributions={setIncludeContributions}
         />
-        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-2">
-          <TimeFrameTabs />
-        </div>
+        <TimeFrameTabs />
       </CardHeader>
       <CardContent>
         <div ref={containerRef} className="h-80 relative">

--- a/portfolio-tracker/src/components/PortfolioOverview.jsx
+++ b/portfolio-tracker/src/components/PortfolioOverview.jsx
@@ -54,7 +54,7 @@ function PortfolioOverview({ portfolioData }) {
     if (active && payload && payload.length) {
       const data = payload[0].payload
       return (
-        <div className="bg-white p-3 border rounded-lg shadow-lg">
+        <div role="tooltip" className="bg-white p-3 border rounded-lg shadow-lg">
           <p className="font-semibold">{data.name}</p>
           <p className="text-sm text-gray-600">
             Value: ${data.value.toLocaleString()}
@@ -72,7 +72,7 @@ function PortfolioOverview({ portfolioData }) {
     if (active && payload && payload.length) {
       const data = payload[0].payload
       return (
-        <div className="bg-white p-3 border rounded-lg shadow-lg">
+        <div role="tooltip" className="bg-white p-3 border rounded-lg shadow-lg">
           <p className="font-semibold">{data.symbol}</p>
           <p className="text-sm text-gray-600">
             Gain/Loss: ${data.gain.toLocaleString()}

--- a/portfolio-tracker/src/components/TimeFrameTabs.tsx
+++ b/portfolio-tracker/src/components/TimeFrameTabs.tsx
@@ -7,7 +7,10 @@ export default function TimeFrameTabs() {
   const { selectedRange, setRange } = usePortfolioStore()
   return (
     <Tabs value={selectedRange} onValueChange={setRange} className="w-full">
-      <TabsList className="grid grid-cols-8 w-full sm:w-fit">
+      <TabsList
+        aria-label="Select time range"
+        className="grid grid-cols-8 w-full sm:w-fit"
+      >
         {ranges.map((r) => (
           <TabsTrigger key={r} value={r} className="px-2">
             {r}


### PR DESCRIPTION
## Summary
- stack chart header vertically on small screens
- label the time range tablist for screen readers
- mark recharts tooltip containers with role="tooltip"

## Testing
- `pnpm test`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6853f3496bc883308bc29989e89961a9