### PR TITLE
Revamp history fetch + chart tests

### DIFF
--- a/portfolio-tracker/src/store/portfolioStore.ts
+++ b/portfolio-tracker/src/store/portfolioStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import debounce from 'lodash.debounce'
 import { get } from '@/lib/api'
+import { DateTime } from 'luxon'
 
 export type TimeRange = '1D' | '5D' | '1M' | '6M' | 'YTD' | '1Y' | '5Y' | 'MAX'
 
@@ -21,12 +22,38 @@ interface PortfolioState {
   fetchHistory: (r?: TimeRange) => void
 }
 
+export function rangeToParams(r: TimeRange) {
+  const today = DateTime.now().startOf('day')
+  switch (r) {
+    case '1D':
+      return { from: today.minus({ days: 1 }), to: today, granularity: 'hour' }
+    case '5D':
+      return { from: today.minus({ days: 5 }), to: today, granularity: 'day' }
+    case '1M':
+      return { from: today.minus({ days: 30 }), to: today, granularity: 'day' }
+    case '6M':
+      return { from: today.minus({ days: 182 }), to: today, granularity: 'week' }
+    case 'YTD':
+      return { from: DateTime.local(today.year, 1, 1), to: today, granularity: 'day' }
+    case '1Y':
+      return { from: today.minus({ days: 365 }), to: today, granularity: 'week' }
+    case '5Y':
+      return { from: today.minus({ days: 365 * 5 }), to: today, granularity: 'month' }
+    case 'MAX':
+      return { from: DateTime.fromISO('1970-01-01'), to: today, granularity: 'month' }
+    default:
+      return { from: today.minus({ days: 30 }), to: today, granularity: 'day' }
+  }
+}
+
 
 export const usePortfolioStore = create<PortfolioState>((set, get) => {
   const doFetch = async (r: TimeRange) => {
     set({ loading: true })
     try {
-      const resp = await get(`/history?range=${r}`)
+      const { from, to, granularity } = rangeToParams(r)
+      const url = `/history?from=${from.toISODate()}&to=${to.toISODate()}&granularity=${granularity}`
+      const resp = await get(url)
       if (resp.ok) {
         const data = await resp.json()
         const history = data.history ?? []

--- a/portfolio-tracker/tests/customTooltip.test.tsx
+++ b/portfolio-tracker/tests/customTooltip.test.tsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import { render } from '@testing-library/react'
+import CustomTooltip from '../src/components/CustomTooltip'
+
+test('tooltip formats date and value', () => {
+  const { container } = render(
+    <CustomTooltip
+      active={true}
+      label="2024-06-01"
+      payload={[{ value: 1234.56 }]}
+    />
+  )
+  expect(container.textContent).toContain('€1,234.56')
+  expect(container.textContent).toContain('01 Jun 2024')
+})

--- a/portfolio-tracker/tests/portfolioHeader.test.tsx
+++ b/portfolio-tracker/tests/portfolioHeader.test.tsx
@@ -40,3 +40,21 @@ test('shows current value and delta', () => {
   expect(screen.getByRole('heading').textContent).toContain('€110')
   expect(screen.getAllByText(/\+10/).length).toBeGreaterThan(0)
 })
+
+test('shows negative delta correctly', () => {
+  act(() => {
+    usePortfolioStore.setState({
+      history: [
+        { date: '2025-06-18', market_value_only: 100, with_contributions: 100 },
+        { date: '2025-06-19', market_value_only: 90, with_contributions: 90 },
+      ],
+    })
+  })
+  render(
+    <Wrapper>
+      <SetEUR />
+      <PortfolioHeader />
+    </Wrapper>
+  )
+  expect(screen.getAllByText(/-10/).length).toBeGreaterThan(0)
+})


### PR DESCRIPTION
## Summary
- update portfolio store to call new `/history` API with from/to & granularity
- add negative delta test in `PortfolioHeader`
- test tooltip formatting

## Testing
- `pnpm test`

------
https://chatgpt.com/codex/tasks/task_e_6853f3638ac8833095e3ca5e68015b64