### PR TITLE
Fix missing static build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,18 @@ pip install -r requirements.txt
 uvicorn src.main:app --reload
 ```
 
+### Production build
+
+To serve the React app from the Flask backend you need to create a production
+build. Run the following inside `portfolio-tracker`:
+
+```bash
+pnpm run build
+```
+
+The compiled files will be written to `portfolio-api/src/static` and served by
+Flask at the root URL.
+
 Each build stamps the current commit hash into the app. The footer will display
 the version like `v4e96b97` corresponding to the commit used for the build.
 

--- a/portfolio-tracker/vite.config.js
+++ b/portfolio-tracker/vite.config.js
@@ -14,4 +14,11 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  build: {
+    // Output the production build into the Flask static folder so
+    // the backend can serve the compiled app without additional
+    // copy steps.
+    outDir: path.resolve(__dirname, "../portfolio-api/src/static"),
+    emptyOutDir: true,
+  },
 })


### PR DESCRIPTION
## Summary
- document how to build the frontend for production
- output built assets into Flask `static` folder via Vite config

## Testing
- `python3 -m pip install -r requirements-dev.txt`
- `pytest`
- `pnpm install`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6856bfbc492883308c862330d12d8ea8