### PR TITLE
Fix mismatched tag in history chart

### DIFF
--- a/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
+++ b/portfolio-tracker/src/components/PortfolioHistoryChart.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState, useRef } from 'react'
 import {
-  LineChart,
+  AreaChart,
   Line,
   XAxis,
   YAxis,
@@ -122,7 +122,7 @@ function PortfolioHistoryChart() {
               ))}
               <Line type="monotone" dataKey={lineKey} stroke="#8884d8" dot={false} />
               {brushEnabled && <Brush dataKey="date" onChange={handleBrushChange} />}
-            </LineChart>
+            </AreaChart>
           </ResponsiveContainer>
         </div>
       </CardContent>


### PR DESCRIPTION
## Summary
- update PortfolioHistoryChart to close the correct tag and import AreaChart

## Testing
- `pnpm test`
- `pytest`
- `pnpm build` *(fails: Rollup failed to resolve import "lodash.debounce" from store/portfolioStore.ts)*

------
https://chatgpt.com/codex/tasks/task_e_6856c35af1f883308a6a8d7b769f4e84