### PR TITLE
Improve API startup & docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Example environment configuration for portfolio-api
+ALPHAVANTAGE_API_KEY=
+PORTFOLIO_BASE_CCY=USD
+FALLBACK_PROVIDER=stooq

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ This repository contains a Flask backend (`portfolio-api`) and a React frontend 
 The front-end uses Vite environment variables. Copy `.env.local.example` in `portfolio-tracker` to `.env.local` and update the values as needed.
 
 ```
-VITE_PORTFOLIO_API=http://localhost:5000/api/portfolio
-VITE_IMPORT_API=http://localhost:5000/api/import
+VITE_PORTFOLIO_API=http://localhost:8000/api/portfolio
+VITE_IMPORT_API=http://localhost:8000/api/import
 VITE_BASE_CURRENCY=USD
 ```
 
@@ -29,16 +29,14 @@ cd ../portfolio-api
 python -m venv venv
 source venv/bin/activate
 pip install -r requirements.txt
-# start the API from the portfolio-api directory
-uvicorn src.main:app --reload
+# start the API from the portfolio-api directory (dev only)
+flask run --reload
 ```
 
-If you want to start the server from the repository root instead of the
-`portfolio-api` directory, pass the `--app-dir` option so Uvicorn can locate
-the `src` package:
+If you prefer running from the repository root set `FLASK_APP` to the backend path:
 
 ```bash
-uvicorn src.main:app --reload --app-dir portfolio-api
+FLASK_APP=portfolio-api/src/main.py flask run --reload
 ```
 
 ### Production build
@@ -48,6 +46,12 @@ build. Run the following inside `portfolio-tracker`:
 
 ```bash
 pnpm run build
+```
+
+After building, start the API with Gunicorn:
+
+```bash
+gunicorn -b 0.0.0.0:8000 "src.main:create_app()"
 ```
 
 Because the compiled assets aren't tracked in Git, be sure to run the build
@@ -69,15 +73,9 @@ When `ALPHAVANTAGE_API_KEY` is set the API will query Alpha Vantage for live
 quotes. If a symbol is not available there, it falls back to [Stooq](https://stooq.com).
 Set `FALLBACK_PROVIDER=stooq` in your `.env` to enable this behaviour.
 
-# My Portfolio
-
-This repository contains a Flask API and a React front-end for tracking investment portfolios.
+This project combines a Flask-based backend API with a modern React frontend to help track stock investments. It allows you to record buy/sell transactions, fetch current prices, and visualize portfolio performance.
 
 The API stores its data in an SQLite database located at `portfolio-api/data/portfolio.db`. This folder is created automatically when the server starts, so it should not be committed to version control.
-
-# Portfolio Tracker
-
-This project combines a Flask-based backend API with a modern React frontend to help track stock investments. It allows you to record buy/sell transactions, fetch current prices, and visualize portfolio performance.
 
 ## Features
 
@@ -137,7 +135,7 @@ pip install -r requirements.txt
 python src/main.py
 ```
 
-The API will start on `http://localhost:5000`.
+The API will start on `http://localhost:8000`.
 
 ## Frontend Setup
 
@@ -196,6 +194,16 @@ Paste your Google Finance activity text directly into the app.
 Open the **Import ▸ Google Finance** dialog on the Transactions page, preview the
 parsed rows and confirm to save them. Save the confirmed rows to your portfolio
 with the **Confirm & Save** button.
+
+### Deploying on Raspberry Pi
+
+Copy the systemd unit and enable the service:
+
+```bash
+sudo cp deploy/portfolio-api.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now portfolio-api
+```
 
 ## Running Tests
 

--- a/deploy/portfolio-api.service
+++ b/deploy/portfolio-api.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=Portfolio API (gunicorn)
+After=network.target
+
+[Service]
+WorkingDirectory=/home/admin/my-portfolio/portfolio-api
+EnvironmentFile=/home/admin/my-portfolio/.env
+ExecStart=/home/admin/my-portfolio/portfolio-api/venv/bin/gunicorn -w 2 -b 0.0.0.0:${PORT:=8000} "src.main:create_app()"
+Restart=on-failure
+User=admin
+Group=admin
+
+[Install]
+WantedBy=multi-user.target

--- a/portfolio-api/requirements.txt
+++ b/portfolio-api/requirements.txt
@@ -14,3 +14,5 @@ uvicorn==0.29.0
 alembic==1.13.1
 pandas==2.3.0
 openpyxl==3.1.5
+gunicorn==23.0.0
+python-dotenv==1.1.0

--- a/portfolio-api/src/main.py
+++ b/portfolio-api/src/main.py
@@ -1,56 +1,58 @@
 import os
 import sys
+from dotenv import load_dotenv, find_dotenv
+from flask import Flask, send_from_directory
+from flask_cors import CORS
+
 # DON'T CHANGE THIS !!!
 sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
 
-from flask import Flask, send_from_directory
-from flask_cors import CORS
+load_dotenv(find_dotenv())
+
 from src.models.user import db
-from src.models.portfolio import Stock, Transaction
 from src.routes.user import user_bp
 from src.routes.portfolio import portfolio_bp, prices_bp
 from src.routes.import_routes import import_bp
 from src.routes.fx import fx_bp
-from src.config import SQLALCHEMY_DATABASE_URI
+from src.config import SQLALCHEMY_DATABASE_URI, PORTFOLIO_BASE_CCY
 
-app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
-# Enable CORS for all API routes
-CORS(app, resources={r"/api/*": {"origins": "*"}})
-# Allow SECRET_KEY to be configured via environment variable for flexibility
-app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'asdf#FGSgvasgf$5$WGT')
-from src.config import PORTFOLIO_BASE_CCY
-app.config['PORTFOLIO_BASE_CCY'] = PORTFOLIO_BASE_CCY
-app.config['BASE_CURRENCY'] = PORTFOLIO_BASE_CCY
 
-app.register_blueprint(user_bp, url_prefix='/api')
-app.register_blueprint(portfolio_bp, url_prefix='/api/portfolio')
-app.register_blueprint(prices_bp, url_prefix='/api/prices')
-app.register_blueprint(import_bp, url_prefix='/api/import')
-app.register_blueprint(fx_bp, url_prefix='/api/fx')
+def create_app() -> Flask:
+    app = Flask(__name__, static_folder=os.path.join(os.path.dirname(__file__), 'static'))
+    CORS(app, resources={r"/api/*": {"origins": "*"}})
+    app.config['SECRET_KEY'] = os.environ.get('SECRET_KEY', 'asdf#FGSgvasgf$5$WGT')
+    app.config['PORTFOLIO_BASE_CCY'] = PORTFOLIO_BASE_CCY
+    app.config['BASE_CURRENCY'] = PORTFOLIO_BASE_CCY
+    app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', SQLALCHEMY_DATABASE_URI)
+    app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
 
-# uncomment if you need to use database
-app.config['SQLALCHEMY_DATABASE_URI'] = os.environ.get('DATABASE_URL', SQLALCHEMY_DATABASE_URI)
-app.config['SQLALCHEMY_TRACK_MODIFICATIONS'] = False
-db.init_app(app)
-with app.app_context():
-    db.create_all()
+    db.init_app(app)
 
-@app.route('/', defaults={'path': ''})
-@app.route('/<path:path>')
-def serve(path):
-    static_folder_path = app.static_folder
-    if static_folder_path is None:
+    app.register_blueprint(user_bp, url_prefix='/api')
+    app.register_blueprint(portfolio_bp, url_prefix='/api/portfolio')
+    app.register_blueprint(prices_bp, url_prefix='/api/prices')
+    app.register_blueprint(import_bp, url_prefix='/api/import')
+    app.register_blueprint(fx_bp, url_prefix='/api/fx')
+
+    with app.app_context():
+        db.create_all()
+
+    @app.route('/', defaults={'path': ''})
+    @app.route('/<path:path>')
+    def serve(path: str):
+        static_folder_path = app.static_folder
+        if static_folder_path is None:
             return "Static folder not configured", 404
 
-    if path != "" and os.path.exists(os.path.join(static_folder_path, path)):
-        return send_from_directory(static_folder_path, path)
-    else:
+        if path != "" and os.path.exists(os.path.join(static_folder_path, path)):
+            return send_from_directory(static_folder_path, path)
         index_path = os.path.join(static_folder_path, 'index.html')
         if os.path.exists(index_path):
             return send_from_directory(static_folder_path, 'index.html')
-        else:
-            return "index.html not found", 404
+        return "index.html not found", 404
+
+    return app
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000, debug=True)
+    create_app().run(host='0.0.0.0', port=int(os.environ.get('PORT', 8000)), debug=True)

--- a/start-api.sh
+++ b/start-api.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -e
+
+# Change to the backend directory
+cd "$(dirname "$0")/portfolio-api"
+
+# Prevent starting duplicate workers
+if pgrep -f "gunicorn.*src.main:create_app" >/dev/null; then
+  echo "Gunicorn already running"
+  exit 0
+fi
+
+# Create virtual environment if needed
+if [ ! -d venv ]; then
+  python3 -m venv venv
+fi
+source venv/bin/activate
+
+# Upgrade pip safely
+python -m pip install -U pip > /dev/null
+
+# Install requirements only when packages are outdated or on first run
+if [ ! -f venv/.deps_installed ] || pip list --outdated --format=columns | grep -q .; then
+  pip install -r requirements.txt
+  touch venv/.deps_installed
+fi
+
+exec gunicorn -w 2 -b 0.0.0.0:${PORT:=8000} "src.main:create_app()"


### PR DESCRIPTION
## Summary
- serve Flask with gunicorn
- load environment with python-dotenv
- provide example `.env`
- add systemd service file
- document new production start and Pi deployment steps
- tidy duplicated README sections

## Testing
- `pytest -q`
- `bash start-api.sh` *(checked gunicorn start and stop)*

------
https://chatgpt.com/codex/tasks/task_e_6858f36a655483308e358ebc31ff846d