### PR TITLE
Clarify API key configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,29 @@ VITE_BASE_CURRENCY=USD
 `VITE_IMPORT_API` is used for bulk import endpoints.
 `VITE_BASE_CURRENCY` sets the default currency shown in the UI.
 
+### Backend `.env`
+
+The Flask API loads environment variables from a `.env` file in the repository
+root. Copy `.env.example` to `.env` and fill in any required keys:
+
+```
+ALPHAVANTAGE_API_KEY=your-alpha-key
+PORTFOLIO_BASE_CCY=USD
+FALLBACK_PROVIDER=stooq
+FX_PROVIDER_URL=https://api.exchangerate.host
+FX_API_KEY=
+DATA_API_BASE_URL=
+DATA_API_KEY=
+```
+
+`ALPHAVANTAGE_API_KEY` enables live quotes from Alpha Vantage. If omitted the
+API relies solely on Manus API Hub and Stooq for prices. `FX_PROVIDER_URL` and
+`FX_API_KEY` configure the foreign exchange rates provider. `DATA_API_BASE_URL`
+and `DATA_API_KEY` point the helper `ApiClient` to an external data source.
+`FALLBACK_PROVIDER` chooses the backup quote service when the primary lookup
+fails. All of these values can also be set directly in the environment instead
+of the `.env` file.
+
 ## Getting Started
 
 This project requires **Node.js 20** and **Python 3.11+**.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -22,6 +22,19 @@ API returns no data (or the symbol is unsupported), the implementation falls
 back to the Stooq provider. Results are cached in memory for 60&nbsp;seconds to
 avoid hitting the APIs repeatedly.
 
+### Configuration & API keys
+
+The backend reads its provider settings from environment variables (or a `.env`
+file loaded via *python-dotenv*). Important variables include:
+
+* `ALPHAVANTAGE_API_KEY` – optional key enabling Alpha Vantage quotes.
+* `FALLBACK_PROVIDER` – provider to query when the main service fails.
+* `FX_PROVIDER_URL` – endpoint for currency rates, defaults to
+  `https://api.exchangerate.host`.
+* `FX_API_KEY` – authentication token for the FX provider (if required).
+* `DATA_API_BASE_URL` / `DATA_API_KEY` – base URL and token for the external data
+  API used by `ApiClient`.
+
 ## manual override route
 
 The `/api/fx/override` endpoint accepts a JSON body containing `date`, `base`,


### PR DESCRIPTION
## Summary
- document how API keys are loaded from the `.env`
- outline provider-related environment variables in `docs/architecture.md`

## Testing
- `pip install -r requirements-dev.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6859035f97708330926a924aa1e32c62